### PR TITLE
feat: surface artist profile and shop cards in single-post network bridge

### DIFF
--- a/inc/single/network-bridge.php
+++ b/inc/single/network-bridge.php
@@ -1,13 +1,14 @@
 <?php
 /**
- * From Around the Extra Chill Network — Single Post Bridge (v1)
+ * From Around the Extra Chill Network — Single Post Bridge
  *
  * Routes attention from high-traffic evergreen blog posts (the residual
  * song-meaning / music-history catalog) into the live platform surfaces
- * that breathe daily: the events calendar, the festival news wire, and the
- * community. The vast majority of network search traffic lands on these
- * single posts and dead-ends there; this section gives the reader a
- * contextual path one click deeper into the network.
+ * that breathe daily: the artist's profile hub, the events calendar, the
+ * festival news wire, the shop, and the community. The vast majority of
+ * network search traffic lands on these single posts and dead-ends there;
+ * this section gives the reader a contextual path one click deeper into the
+ * network.
  *
  * Relevance is driven entirely by the post's own taxonomy terms. Blog posts,
  * events, and wire posts share the network-wide `artist` and `festival`
@@ -80,11 +81,13 @@ add_action( 'extrachill_after_post_content', 'extrachill_blog_network_bridge', 6
 /**
  * Build the (cached) set of cross-site cards for a single post.
  *
- * Resolves up to three contextual destinations from the post's artist and
+ * Resolves up to five contextual destinations from the post's artist and
  * festival terms:
- *   1. A relevant upcoming event (events.extrachill.com)
- *   2. A relevant wire story (wire.extrachill.com)
- *   3. A community entry point (community.extrachill.com)
+ *   1. The artist's profile hub (artist.extrachill.com)
+ *   2. A relevant upcoming event (events.extrachill.com)
+ *   3. A relevant wire story (wire.extrachill.com)
+ *   4. Relevant merch (shop.extrachill.com)
+ *   5. A community entry point (community.extrachill.com)
  *
  * Mirrors the 1-hour transient pattern used by the theme's related-posts
  * helper, keyed by post ID plus a signature of the post's matching terms so
@@ -159,11 +162,15 @@ function extrachill_blog_network_bridge_terms( $post_id, $taxonomy ) {
 }
 
 /**
- * Assemble up to three contextual cards from the post's terms.
+ * Assemble up to five contextual cards from the post's terms.
  *
- * Order of preference for the three slots:
+ * Order of preference for the slots:
+ *   - Profile:   the artist's profile hub on the artist platform (the live
+ *                destination the #62 term↔profile binding hardens). Resolved by
+ *                the engine via the artist term, surfaced here for the first time.
  *   - Event:     first artist term with upcoming events, else first festival term.
  *   - Wire:      first festival term with wire coverage, else first artist term.
+ *   - Shop:      relevant merch for the artist term, when the shop has products.
  *   - Community: contextual entry point (artist-first, festival fallback). Always
  *                present as a guaranteed path into the community.
  *
@@ -173,7 +180,7 @@ function extrachill_blog_network_bridge_terms( $post_id, $taxonomy ) {
  *
  * @param WP_Term[] $artist_terms   Artist terms on the post.
  * @param WP_Term[] $festival_terms Festival terms on the post.
- * @return array Up to three link arrays.
+ * @return array Up to five link arrays.
  */
 function extrachill_blog_network_bridge_build_cards( $artist_terms, $festival_terms ) {
 	// Gather candidate cross-site links from every matchable term, keyed by
@@ -189,17 +196,29 @@ function extrachill_blog_network_bridge_build_cards( $artist_terms, $festival_te
 
 	$cards = array();
 
-	// Slot 1 — a relevant upcoming event.
+	// Slot 1 — the artist's profile hub. The engine resolves this from the
+	// artist term (the #62 term↔profile binding); it is the highest-value
+	// destination because the profile is the artist's live home on the network.
+	if ( isset( $by_site['artist'] ) ) {
+		$cards['artist'] = $by_site['artist'];
+	}
+
+	// Slot 2 — a relevant upcoming event.
 	if ( isset( $by_site['events'] ) ) {
 		$cards['events'] = $by_site['events'];
 	}
 
-	// Slot 2 — a relevant wire story.
+	// Slot 3 — a relevant wire story.
 	if ( isset( $by_site['wire'] ) ) {
 		$cards['wire'] = $by_site['wire'];
 	}
 
-	// Slot 3 — a guaranteed community entry point. Prefer a real
+	// Slot 4 — relevant merch, when the shop has products for the artist term.
+	if ( isset( $by_site['shop'] ) ) {
+		$cards['shop'] = $by_site['shop'];
+	}
+
+	// Slot 5 — a guaranteed community entry point. Prefer a real
 	// community match from the engine; otherwise synthesize a contextual link
 	// into the community keyed on the post's primary artist/festival term.
 	if ( isset( $by_site['community'] ) ) {
@@ -243,11 +262,11 @@ function extrachill_blog_network_bridge_collect( &$by_site, $term, $taxonomy ) {
 	}
 
 	foreach ( $links as $link ) {
-		// Only surface the live platform surfaces in v1. The main blog itself
-		// is the current page's site and is never a "from around the network"
-		// destination; artist/shop are out of scope for the v1 three-card set.
+		// Surface the live platform surfaces plus the artist's own profile hub
+		// and shop. The main blog itself is the current page's site and is never
+		// a "from around the network" destination, so it stays filtered out.
 		$site_key = isset( $link['site_key'] ) ? $link['site_key'] : '';
-		if ( ! in_array( $site_key, array( 'events', 'wire', 'community' ), true ) ) {
+		if ( ! in_array( $site_key, array( 'artist', 'events', 'wire', 'shop', 'community' ), true ) ) {
 			continue;
 		}
 


### PR DESCRIPTION
## Summary

Surfaces the **Artist Profile** card (and a **Shop** card) in the single-post "From Around the Extra Chill Network" bridge. Per the corrected scope on #9, the bridge engine *already computed* the artist profile (via `extrachill_get_artist_profile_by_slug()` — the destination the artist-platform#62 term↔profile binding hardens) and shop products, but `extrachill_blog_network_bridge_collect()` **hard-filtered the card set to `events`/`wire`/`community`** in v1. A reader of a band article therefore had no one-click path to that band's live profile hub or merch — the single highest-value network-density jump.

This PR removes that filter and wires the two computed destinations into the rendered card set.

## Changes

- **Remove the v1 hard-filter** in `extrachill_blog_network_bridge_collect()` — now accepts `artist`, `events`, `wire`, `shop`, `community` site_keys (main blog stays filtered out: it's the current page's site).
- **Add Slot 1 — Artist Profile**: the highest-value destination, resolved by the engine from the artist term (the #62 binding). The profile is the artist's live home on the network.
- **Add Slot 4 — Shop**: relevant merch for the artist term, count-gated by the engine (`extrachill_get_shop_taxonomy_count_via_api()` skips when there are no products), so it stays graceful-empty.
- Reorders slots to: Profile → Event → Wire → Shop → Community (community remains a guaranteed entry point via the synthesized search card).
- Docblock updates to reflect the five-slot model.

## Preserved (no rebuild)

- **UTM tagging** — `extrachill_blog_network_bridge_tag_url()` already tags every outbound link (`utm_source=extrachill_blog&utm_medium=network_bridge&utm_campaign={site_key}`); the new cards flow through it unchanged.
- **Caching** — the existing 1-hour transient keyed on post ID + term signature is untouched.
- **Graceful-empty** — engine count-gating (`count < 1` → skipped) keeps shop/profile cards from rendering when there's nothing to link to.
- **No new infrastructure** — consumes the existing `extrachill_get_cross_site_term_links()` engine (RULES.md: don't rebuild what exists).

## Verification

Confirmed against `extrachill-multisite/inc/cross-site-links/taxonomy-links.php` that the engine emits both `artist` (line 146-151, profile-by-slug) and `shop` (line 156-157, product count) site_keys with `count`/`url`, so neither card is dead.

Gate: artist-platform#62 (PR #66) is **merged** — the term↔profile binding the profile card depends on is live.

Closes #9