### PR TITLE
feat: add /power network manifesto landing page

### DIFF
--- a/assets/css/power.css
+++ b/assets/css/power.css
@@ -1,0 +1,75 @@
+/**
+ * Styles for the /power manifesto page.
+ *
+ * Scoped to the network-map dynamic block only. The manifesto pillars and hero
+ * are composed from core blocks + the theme's `extrachill/pillar` pattern, so
+ * they inherit the EC brand from theme.json with no CSS here. This file only
+ * lays out the surface-card grid the dynamic block emits, using theme tokens
+ * (no hardcoded values, no !important).
+ */
+
+.power-network-map {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: var(--spacing-md);
+	margin: var(--spacing-lg) 0;
+}
+
+@media (min-width: 600px) {
+	.power-network-map {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+@media (min-width: 900px) {
+	.power-network-map {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+}
+
+.power-network-card {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-sm);
+	padding: var(--spacing-lg);
+	background: var(--card-background);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-lg);
+	text-decoration: none;
+	color: var(--text-color);
+	transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.power-network-card:hover,
+.power-network-card:focus {
+	border-color: var(--accent);
+	transform: translateY(-2px);
+}
+
+.power-network-card__title {
+	margin: 0;
+	font-family: var(--font-family-heading);
+	font-size: var(--font-size-lg);
+	color: var(--text-color);
+}
+
+.power-network-card__proof {
+	margin: 0;
+	font-family: var(--font-family-heading);
+	font-size: var(--font-size-xl);
+	color: var(--accent);
+	line-height: 1.1;
+}
+
+.power-network-card__desc {
+	margin: 0;
+	font-size: var(--font-size-base);
+	color: var(--muted-text);
+	flex: 1 1 auto;
+}
+
+.power-network-card__cta {
+	font-size: var(--font-size-sm);
+	font-weight: 600;
+	color: var(--link-color);
+}

--- a/extrachill-blog.php
+++ b/extrachill-blog.php
@@ -31,6 +31,8 @@ require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/co-authors.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/admin-customizations.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/ads-filter.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/home/homepage-hooks.php';
+require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/power/network-map-block.php';
+require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/power/power-page.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/blog-archive-routing.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/breadcrumbs.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/share-card.php';
@@ -55,3 +57,16 @@ function extrachill_blog_register_styles() {
 	);
 }
 add_action( 'wp_enqueue_scripts', 'extrachill_blog_register_styles', 5 );
+
+/**
+ * Provision the /power manifesto page on activation.
+ *
+ * The version-gated admin_init check in inc/power/power-page.php handles
+ * upgrades; this guarantees the page exists immediately on fresh activation.
+ */
+function extrachill_blog_activate() {
+	if ( function_exists( 'extrachill_blog_create_power_page' ) ) {
+		extrachill_blog_create_power_page();
+	}
+}
+register_activation_hook( __FILE__, 'extrachill_blog_activate' );

--- a/inc/power/network-map-block.php
+++ b/inc/power/network-map-block.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * Network Map dynamic block for the /power manifesto page.
+ *
+ * Renders the "network map" section of extrachill.com/power: a grid of surface
+ * cards (Live Music Calendar, The Community, Festival Wire, Artist Platform,
+ * The Publication), each carrying a LIVE proof-number sourced from
+ * ec_get_network_stats() and a deep link into the corresponding subsite.
+ *
+ * Why a dynamic (server-rendered) block instead of a static theme pattern:
+ *  - The theme deliberately does NOT ship a static `extrachill/network-map`
+ *    pattern. It was dropped (theme PR #38) precisely because hardcoded /
+ *    placeholder proof numbers on a credibility-driven manifesto page are worse
+ *    than none. Live numbers must come from NetworkStats at render time.
+ *  - Storing live numbers in a page's post_content would freeze them; rendering
+ *    them in a dynamic block keeps the page honest and self-updating.
+ *  - extrachill-blog has no JS build system (see CLAUDE.md), so this block is
+ *    PHP-only: registered with a render_callback and no editor script. It is not
+ *    insertable in the editor — it is seeded into the /power page content
+ *    programmatically (mirroring how the artist platform seeds self-closing
+ *    dynamic blocks like `<!-- wp:extrachill/artist-creator /-->`).
+ *
+ * Graceful degradation: every NetworkStats read is guarded with
+ * function_exists( 'ec_get_network_stats' ) and each metric is checked for
+ * `available`. When a number is unavailable the card still renders with its
+ * label and link — it just omits the proof number. The page never fatals if
+ * extrachill-multisite is a version behind.
+ *
+ * @package ExtraChillBlog
+ * @since 0.6.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the extrachill/network-map dynamic block.
+ *
+ * PHP-only block: a render_callback with no editor script. Safe to call on
+ * `init`; bails if block registration is unavailable.
+ */
+function extrachill_blog_register_network_map_block() {
+	if ( ! function_exists( 'register_block_type' ) ) {
+		return;
+	}
+
+	register_block_type(
+		'extrachill/network-map',
+		array(
+			'api_version'     => 2,
+			'title'           => __( 'Network Map', 'extrachill-blog' ),
+			'description'     => __( 'Surface cards for the Extra Chill network with live proof numbers and deep links. Used on the /power manifesto page.', 'extrachill-blog' ),
+			'category'        => 'widgets',
+			'render_callback' => 'extrachill_blog_render_network_map_block',
+			'supports'        => array(
+				'html'     => false,
+				'reusable' => false,
+			),
+		)
+	);
+}
+add_action( 'init', 'extrachill_blog_register_network_map_block' );
+
+/**
+ * Resolve the live network statistics needed by the network map.
+ *
+ * Single guarded call to ec_get_network_stats() for all keys the map consumes.
+ * Returns an empty array when the NetworkStats primitive is unavailable so the
+ * renderer degrades to label-only cards.
+ *
+ * @return array<string,array{key:string,label:string,value:int|array|null,available:bool}>
+ */
+function extrachill_blog_get_network_map_stats() {
+	if ( ! function_exists( 'ec_get_network_stats' ) ) {
+		return array();
+	}
+
+	$keys = array(
+		'events_count',
+		'events_cities',
+		'community_members',
+		'community_topics',
+		'wire_posts',
+		'artist_profiles',
+		'total_posts',
+	);
+
+	$stats = ec_get_network_stats( $keys );
+
+	return is_array( $stats ) ? $stats : array();
+}
+
+/**
+ * Extract a single integer proof-number from a NetworkStats envelope map.
+ *
+ * Honors the "honesty rule": returns null unless the metric is explicitly
+ * available with a numeric value.
+ *
+ * @param array  $stats NetworkStats envelope map keyed by metric.
+ * @param string $key   Metric key.
+ * @return int|null Integer value or null when unavailable.
+ */
+function extrachill_blog_network_stat_value( array $stats, $key ) {
+	if ( empty( $stats[ $key ] ) || ! is_array( $stats[ $key ] ) ) {
+		return null;
+	}
+
+	$metric = $stats[ $key ];
+
+	if ( empty( $metric['available'] ) ) {
+		return null;
+	}
+
+	$value = isset( $metric['value'] ) ? $metric['value'] : null;
+
+	if ( is_int( $value ) || is_numeric( $value ) ) {
+		return (int) $value;
+	}
+
+	return null;
+}
+
+/**
+ * Build the proof-number line for a card from one or more metric fragments.
+ *
+ * Each fragment is rendered as "{number} {label}" only when its value is
+ * available; unavailable fragments are dropped. Returns an empty string when no
+ * fragment resolves, so the caller can omit the proof line entirely.
+ *
+ * @param array $stats     NetworkStats envelope map.
+ * @param array $fragments List of [ 'key' => metric_key, 'singular' => 'event', 'plural' => 'events' ].
+ * @return string Escaped, human-readable proof line (may be empty).
+ */
+function extrachill_blog_network_proof_line( array $stats, array $fragments ) {
+	$parts = array();
+
+	foreach ( $fragments as $fragment ) {
+		$value = extrachill_blog_network_stat_value( $stats, $fragment['key'] );
+
+		if ( null === $value ) {
+			continue;
+		}
+
+		$noun = ( 1 === $value )
+			? $fragment['singular']
+			: $fragment['plural'];
+
+		$parts[] = number_format_i18n( $value ) . ' ' . $noun;
+	}
+
+	return implode( ' across ', $parts );
+}
+
+/**
+ * Render callback for the extrachill/network-map block.
+ *
+ * @return string Block HTML.
+ */
+function extrachill_blog_render_network_map_block() {
+	$stats = extrachill_blog_get_network_map_stats();
+
+	$site_url = static function ( $key, $fallback ) {
+		if ( function_exists( 'ec_get_site_url' ) ) {
+			$url = ec_get_site_url( $key );
+			if ( ! empty( $url ) ) {
+				return $url;
+			}
+		}
+		return $fallback;
+	};
+
+	$cards = array(
+		array(
+			'title' => __( 'Live Music Calendar', 'extrachill-blog' ),
+			'desc'  => __( 'Independent shows and festivals, city by city — built from venue listings, not ad buys.', 'extrachill-blog' ),
+			'url'   => $site_url( 'events', 'https://events.extrachill.com' ),
+			'cta'   => __( 'Browse the calendar', 'extrachill-blog' ),
+			'proof' => extrachill_blog_network_proof_line(
+				$stats,
+				array(
+					array(
+						'key'      => 'events_count',
+						'singular' => __( 'event', 'extrachill-blog' ),
+						'plural'   => __( 'events', 'extrachill-blog' ),
+					),
+					array(
+						'key'      => 'events_cities',
+						'singular' => __( 'city', 'extrachill-blog' ),
+						'plural'   => __( 'cities', 'extrachill-blog' ),
+					),
+				)
+			),
+		),
+		array(
+			'title' => __( 'The Community', 'extrachill-blog' ),
+			'desc'  => __( 'Forums for musicians, fans, and industry folks — the online music scene, in conversation.', 'extrachill-blog' ),
+			'url'   => $site_url( 'community', 'https://community.extrachill.com' ),
+			'cta'   => __( 'Join the conversation', 'extrachill-blog' ),
+			'proof' => extrachill_blog_network_proof_line(
+				$stats,
+				array(
+					array(
+						'key'      => 'community_members',
+						'singular' => __( 'member', 'extrachill-blog' ),
+						'plural'   => __( 'members', 'extrachill-blog' ),
+					),
+					array(
+						'key'      => 'community_topics',
+						'singular' => __( 'topic', 'extrachill-blog' ),
+						'plural'   => __( 'topics', 'extrachill-blog' ),
+					),
+				)
+			),
+		),
+		array(
+			'title' => __( 'Festival Wire', 'extrachill-blog' ),
+			'desc'  => __( 'Timely, no-nonsense coverage of festival news and lineups as it breaks.', 'extrachill-blog' ),
+			'url'   => $site_url( 'wire', 'https://wire.extrachill.com' ),
+			'cta'   => __( 'Read the Wire', 'extrachill-blog' ),
+			'proof' => extrachill_blog_network_proof_line(
+				$stats,
+				array(
+					array(
+						'key'      => 'wire_posts',
+						'singular' => __( 'dispatch', 'extrachill-blog' ),
+						'plural'   => __( 'dispatches', 'extrachill-blog' ),
+					),
+				)
+			),
+		),
+		array(
+			'title' => __( 'Artist Platform', 'extrachill-blog' ),
+			'desc'  => __( 'Free link pages, forums, and merch tools for independent artists to run their own corner.', 'extrachill-blog' ),
+			'url'   => $site_url( 'artist', 'https://artist.extrachill.com' ),
+			'cta'   => __( 'Explore the platform', 'extrachill-blog' ),
+			'proof' => extrachill_blog_network_proof_line(
+				$stats,
+				array(
+					array(
+						'key'      => 'artist_profiles',
+						'singular' => __( 'artist profile', 'extrachill-blog' ),
+						'plural'   => __( 'artist profiles', 'extrachill-blog' ),
+					),
+				)
+			),
+		),
+		array(
+			'title' => __( 'The Publication', 'extrachill-blog' ),
+			'desc'  => __( 'Where it all started in 2011 — independent music journalism, written by people who show up.', 'extrachill-blog' ),
+			'url'   => home_url( '/' ),
+			'cta'   => __( 'Read the blog', 'extrachill-blog' ),
+			'proof' => extrachill_blog_network_proof_line(
+				$stats,
+				array(
+					array(
+						'key'      => 'total_posts',
+						'singular' => __( 'article', 'extrachill-blog' ),
+						'plural'   => __( 'articles', 'extrachill-blog' ),
+					),
+				)
+			),
+		),
+	);
+
+	ob_start();
+	?>
+	<div class="power-network-map">
+		<?php foreach ( $cards as $card ) : ?>
+			<a class="power-network-card" href="<?php echo esc_url( $card['url'] ); ?>">
+				<h3 class="power-network-card__title"><?php echo esc_html( $card['title'] ); ?></h3>
+				<?php if ( ! empty( $card['proof'] ) ) : ?>
+					<p class="power-network-card__proof"><?php echo esc_html( $card['proof'] ); ?></p>
+				<?php endif; ?>
+				<p class="power-network-card__desc"><?php echo esc_html( $card['desc'] ); ?></p>
+				<span class="power-network-card__cta"><?php echo esc_html( $card['cta'] ); ?></span>
+			</a>
+		<?php endforeach; ?>
+	</div>
+	<?php
+	return trim( ob_get_clean() );
+}

--- a/inc/power/power-page.php
+++ b/inc/power/power-page.php
@@ -1,0 +1,303 @@
+<?php
+/**
+ * The /power network manifesto landing page.
+ *
+ * The /power surface is the network MANIFESTO + router: it tells outsiders
+ * Extra Chill is a whole independent-music NETWORK (events, community, wire,
+ * artist platform, publication), not just a blog. It is manifesto-first,
+ * routing-second — it LINKS to the live surfaces, it does not embed cross-blog
+ * functional blocks.
+ *
+ * Approach (page-as-content):
+ *  - /power is a standard published WP Page at the (confirmed-free) slug
+ *    "power", auto-created on activation and re-checked on a version-gated
+ *    admin_init — exactly the pattern the artist platform uses to provision
+ *    /create-artist et al. (extrachill-artist-platform.php). This is the
+ *    established main-site convention: main-site custom pages (About, History,
+ *    Long Term Vision) are just published Pages, and they render through the
+ *    theme's normal loop + inc/single/single-page.php (which calls
+ *    the_content()). No new rewrite/route is needed, and the change is purely
+ *    additive: it touches nothing about the homepage or existing pages.
+ *  - The page content is COMPOSED from the theme's `extrachill/pillar` block
+ *    pattern (the values unit: heading + statement + CTA) for the manifesto
+ *    pillars, plus the `extrachill/network-map` dynamic block (this plugin) for
+ *    the live-proof-number network map. The pillar markup uses the theme.json
+ *    preset classes so it inherits the EC brand with zero bespoke CSS.
+ *
+ * Why pillar markup is inlined here rather than fetched from the pattern
+ * registry: the page is seeded programmatically (no human places the pattern in
+ * the editor), so we write the same core-block markup the pattern ships. If the
+ * theme pattern ever diverges, the page can be re-seeded; the markup is kept in
+ * sync with theme `inc/core/editor/block-patterns.php`.
+ *
+ * Additive + router guarantees:
+ *  - New slug, new page; nothing links to it by default (the link-page footer
+ *    re-aim is artist-platform#76, intentionally not touched here).
+ *  - Cards deep-link OUT to the subsites; the page embeds no cross-blog
+ *    functional blocks.
+ *  - The artist conversion section carries an #artists anchor so the future
+ *    footer re-aim can target it directly.
+ *
+ * @package ExtraChillBlog
+ * @since 0.6.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Slug for the manifesto page.
+ */
+const EXTRACHILL_BLOG_POWER_SLUG = 'power';
+
+/**
+ * Build one pillar values unit as core-block markup.
+ *
+ * Mirrors the theme's registered `extrachill/pillar` pattern (heading +
+ * statement + one CTA inside a padded card Group), using the same theme.json
+ * preset classes so it inherits the EC palette/typography with no extra CSS.
+ *
+ * @param string $heading   Pillar headline.
+ * @param string $statement Short, punchy statement.
+ * @param string $cta_label Call-to-action label.
+ * @param string $cta_url   Call-to-action URL.
+ * @return string Block markup for a single pillar.
+ */
+function extrachill_blog_power_pillar( $heading, $statement, $cta_label, $cta_url ) {
+	$heading   = esc_html( $heading );
+	$statement = esc_html( $statement );
+	$cta_label = esc_html( $cta_label );
+	$cta_url   = esc_url( $cta_url );
+
+	return <<<HTML
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|spacing-xl","bottom":"var:preset|spacing|spacing-xl","left":"var:preset|spacing|spacing-lg","right":"var:preset|spacing|spacing-lg"},"blockGap":"var:preset|spacing|spacing-md"}},"backgroundColor":"card-background","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-card-background-background-color has-background" style="padding-top:var(--wp--preset--spacing--spacing-xl);padding-right:var(--wp--preset--spacing--spacing-lg);padding-bottom:var(--wp--preset--spacing--spacing-xl);padding-left:var(--wp--preset--spacing--spacing-lg)"><!-- wp:heading {"level":2,"fontSize":"font-size-2xl"} -->
+<h2 class="wp-block-heading has-font-size-2xl-font-size">{$heading}</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"font-size-body"} -->
+<p class="has-font-size-body-font-size">{$statement}</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"accent","textColor":"button-text-color"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-button-text-color-color has-accent-background-color has-text-color has-background wp-element-button" href="{$cta_url}">{$cta_label}</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group -->
+HTML;
+}
+
+/**
+ * Compose the full block content for the /power manifesto page.
+ *
+ * Sections, in order:
+ *   1. HERO — one-line reframe + one low-commitment CTA.
+ *   2. PILLARS — four `extrachill/pillar` values units.
+ *   3. NETWORK MAP — the `extrachill/network-map` dynamic block (live proof
+ *      numbers + deep links).
+ *   4. ARTIST SECTION (#artists) — focused conversion slice for artists.
+ *   5. CLOSING — repeated low-commitment CTA.
+ *
+ * @return string Page block content.
+ */
+function extrachill_blog_power_page_content() {
+	$community_url = ( function_exists( 'ec_get_site_url' ) && ec_get_site_url( 'community' ) )
+		? ec_get_site_url( 'community' )
+		: 'https://community.extrachill.com';
+
+	$artist_url = ( function_exists( 'ec_get_site_url' ) && ec_get_site_url( 'artist' ) )
+		? ec_get_site_url( 'artist' )
+		: 'https://artist.extrachill.com';
+
+	$artist_register_url = trailingslashit( $artist_url ) . 'login/#tab-register';
+
+	$hero = <<<HTML
+<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"top":"var:preset|spacing|spacing-xl","bottom":"var:preset|spacing|spacing-xl"},"blockGap":"var:preset|spacing|spacing-md"}},"layout":{"type":"constrained"}} -->
+<header class="wp-block-group" style="padding-top:var(--wp--preset--spacing--spacing-xl);padding-bottom:var(--wp--preset--spacing--spacing-xl)"><!-- wp:heading {"textAlign":"center","level":1,"fontSize":"font-size-3xl"} -->
+<h1 class="wp-block-heading has-text-align-center has-font-size-3xl-font-size">Extra Chill is the online music scene.</h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center","fontSize":"font-size-lg"} -->
+<p class="has-text-align-center has-font-size-lg-font-size">Not just a blog — an independent, open-source music network. A live calendar, a community of musicians and fans, a festival news wire, and free tools for artists to run their own corner. All grassroots, all independent, no astro-turf.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"accent","textColor":"button-text-color"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-button-text-color-color has-accent-background-color has-text-color has-background wp-element-button" href="{$community_url}">Join the community</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></header>
+<!-- /wp:group -->
+HTML;
+
+	$pillars_intro = <<<'HTML'
+<!-- wp:heading {"textAlign":"center","level":2,"fontSize":"font-size-2xl"} -->
+<h2 class="wp-block-heading has-text-align-center has-font-size-2xl-font-size">The power of staying independent</h2>
+<!-- /wp:heading -->
+HTML;
+
+	$pillar_music = extrachill_blog_power_pillar(
+		'The Power of Independent Music',
+		'Independent artists make the music that actually moves the scene forward. We cover it, calendar it, and point fans straight at it — no major-label gatekeeping, no pay-to-play. The music comes first, every time.',
+		'See what\'s playing',
+		( function_exists( 'ec_get_site_url' ) && ec_get_site_url( 'events' ) ) ? ec_get_site_url( 'events' ) : 'https://events.extrachill.com'
+	);
+
+	$pillar_community = extrachill_blog_power_pillar(
+		'The Power of Community',
+		'We are not shouting into the void. Musicians, fans, and industry folks meet in the same forums, upvote each other, and build real connections. The scene is a conversation, and everyone has a seat at the table.',
+		'Join the conversation',
+		$community_url
+	);
+
+	$pillar_platform = extrachill_blog_power_pillar(
+		'The Power of the Platform',
+		'Every independent artist gets a free home base: a link page at extrachill.link, their own forum, merch tools, and analytics. You own your corner — we just hand you the keys and get out of the way.',
+		'Build your home base',
+		$artist_register_url
+	);
+
+	$pillar_independent = extrachill_blog_power_pillar(
+		'The Power of Staying Independent',
+		'Since 2011, out of a Charleston dorm room. We stand by our core philosophies and never give in to corporate pressure or aggressive monetization. Sustainable, memorable, and built on the spirit of the music — not on getting rich.',
+		'Read our long-term vision',
+		home_url( '/long-term-vision/' )
+	);
+
+	$network_map = "<!-- wp:heading {\"textAlign\":\"center\",\"level\":2,\"fontSize\":\"font-size-2xl\"} -->\n<h2 class=\"wp-block-heading has-text-align-center has-font-size-2xl-font-size\">One network, many doors</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"align\":\"center\",\"fontSize\":\"font-size-body\"} -->\n<p class=\"has-text-align-center has-font-size-body-font-size\">Every surface below is live and growing. Pick a door.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:extrachill/network-map /-->";
+
+	$artist_section = <<<HTML
+<!-- wp:group {"tagName":"section","anchor":"artists","style":{"spacing":{"padding":{"top":"var:preset|spacing|spacing-xl","bottom":"var:preset|spacing|spacing-xl","left":"var:preset|spacing|spacing-lg","right":"var:preset|spacing|spacing-lg"},"blockGap":"var:preset|spacing|spacing-md"}},"backgroundColor":"card-background","layout":{"type":"constrained"}} -->
+<section class="wp-block-group has-card-background-background-color has-background" id="artists" style="padding-top:var(--wp--preset--spacing--spacing-xl);padding-right:var(--wp--preset--spacing--spacing-lg);padding-bottom:var(--wp--preset--spacing--spacing-xl);padding-left:var(--wp--preset--spacing--spacing-lg)"><!-- wp:heading {"level":2,"fontSize":"font-size-2xl"} -->
+<h2 class="wp-block-heading has-font-size-2xl-font-size">Are you an artist? Here's your home base.</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"font-size-body"} -->
+<p class="has-font-size-body-font-size">Extra Chill gives independent artists real tools, free, with no catch:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list {"fontSize":"font-size-body"} -->
+<ul class="has-font-size-body-font-size"><!-- wp:list-item -->
+<li>A free link page at extrachill.link — your whole presence at one URL.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Your own forum to talk directly with fans.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Tools to sell merch on your terms.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Get discovered by a community that actually shows up.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Analytics so you can see what's working.</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"accent","textColor":"button-text-color"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-button-text-color-color has-accent-background-color has-text-color has-background wp-element-button" href="{$artist_register_url}">Claim your free artist profile</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></section>
+<!-- /wp:group -->
+HTML;
+
+	$closing = <<<HTML
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|spacing-xl","bottom":"var:preset|spacing|spacing-xl"},"blockGap":"var:preset|spacing|spacing-md"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--spacing-xl);padding-bottom:var(--wp--preset--spacing--spacing-xl)"><!-- wp:heading {"textAlign":"center","level":2,"fontSize":"font-size-2xl"} -->
+<h2 class="wp-block-heading has-text-align-center has-font-size-2xl-font-size">We hope you'll stick around.</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center","fontSize":"font-size-body"} -->
+<p class="has-text-align-center has-font-size-body-font-size">If independent music is your thing, you're already home. Pull up a chair in the community.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"accent","textColor":"button-text-color"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-button-text-color-color has-accent-background-color has-text-color has-background wp-element-button" href="{$community_url}">Join the community</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group -->
+HTML;
+
+	return implode(
+		"\n\n",
+		array(
+			$hero,
+			$pillars_intro,
+			$pillar_music,
+			$pillar_community,
+			$pillar_platform,
+			$pillar_independent,
+			$network_map,
+			$artist_section,
+			$closing,
+		)
+	);
+}
+
+/**
+ * Ensure the published /power page exists, creating it if absent.
+ *
+ * Idempotent: only inserts when no page with the slug exists. Existing /power
+ * pages (including any human edits) are left untouched.
+ */
+function extrachill_blog_create_power_page() {
+	$existing = get_page_by_path( EXTRACHILL_BLOG_POWER_SLUG );
+
+	if ( $existing ) {
+		return;
+	}
+
+	wp_insert_post(
+		array(
+			'post_title'   => 'The Power of Extra Chill',
+			'post_name'    => EXTRACHILL_BLOG_POWER_SLUG,
+			'post_content' => extrachill_blog_power_page_content(),
+			'post_status'  => 'publish',
+			'post_type'    => 'page',
+		)
+	);
+}
+
+/**
+ * Provision the /power page on a version-gated admin_init.
+ *
+ * Mirrors the artist platform's page-provisioning convention so the page is
+ * (re)created on fresh installs and plugin upgrades alike, without re-running on
+ * every request.
+ */
+function extrachill_blog_maybe_create_power_page() {
+	$stored_version = get_option( 'extrachill_blog_power_page_version', '0' );
+
+	if ( version_compare( $stored_version, EXTRACHILL_BLOG_VERSION, '<' ) ) {
+		extrachill_blog_create_power_page();
+		update_option( 'extrachill_blog_power_page_version', EXTRACHILL_BLOG_VERSION );
+	}
+}
+add_action( 'admin_init', 'extrachill_blog_maybe_create_power_page' );
+
+/**
+ * Enqueue the /power page styles only on the /power page.
+ */
+function extrachill_blog_enqueue_power_styles() {
+	if ( ! is_page( EXTRACHILL_BLOG_POWER_SLUG ) ) {
+		return;
+	}
+
+	$css_path = EXTRACHILL_BLOG_PLUGIN_DIR . 'assets/css/power.css';
+	if ( file_exists( $css_path ) ) {
+		wp_enqueue_style(
+			'extrachill-blog-power',
+			EXTRACHILL_BLOG_PLUGIN_URL . 'assets/css/power.css',
+			array( 'extrachill-root' ),
+			filemtime( $css_path )
+		);
+	}
+}
+add_action( 'wp_enqueue_scripts', 'extrachill_blog_enqueue_power_styles' );


### PR DESCRIPTION
## Summary

Adds **extrachill.com/power** — the network MANIFESTO + router page that tells outsiders Extra Chill is a whole independent-music NETWORK (events, community, wire, artist platform, publication), not just a blog. Manifesto-first, routing-second. Closes #16.

Purely additive: a new published Page at a new (confirmed-free) slug. Touches nothing about the homepage, existing pages, or any existing routing. Nothing links to it by default.

## Page-creation approach chosen + why

**Auto-create a standard published WP Page at slug `power`** — on activation, and re-checked on a version-gated `admin_init` — mirroring the exact pattern `extrachill-artist-platform` uses to provision `/create-artist` et al.

Why (a) over a custom route/template:
- Main-site custom pages (About, History, Long Term Vision) are *all* just published Pages. They render through the theme's normal loop + `inc/single/single-page.php` (which calls `the_content()`), so block content renders with zero new template wiring.
- No new rewrite rule / query var needed → smaller surface, nothing to collide with existing routing.
- Idempotent: only inserts when no `power` page exists; existing/edited pages are left untouched.

## Patterns + how the page is composed

- **Pillars** use the theme's `extrachill/pillar` block pattern (heading + statement + one CTA in a padded card Group). The markup uses theme.json preset classes (`has-font-size-2xl-font-size`, `has-card-background-background-color`, `has-accent-background-color`, …) so it inherits the EC brand with **no bespoke CSS**. Four pillars: Independent Music, Community, the Platform, Staying Independent (real EC voice — grassroots, anti-corporate, "not shouting into the void").
- **Network map**: the theme deliberately **does NOT ship a static `extrachill/network-map` pattern** — it was dropped in theme PR #38 (`refactor: drop static network-map pattern; live stats belong in a binding`) precisely because hardcoded/placeholder proof numbers on a credibility page are worse than none, and the intended binding source isn't built yet. So this PR delivers the network map as a **PHP-only dynamic block** (`extrachill/network-map`, registered in this plugin with a `render_callback`, no JS — matching extrachill-blog's no-build-system convention). It server-renders the surface cards with **live** proof numbers at render time and is seeded into the page as a self-closing `<!-- wp:extrachill/network-map /-->` block (same technique the artist platform uses for `<!-- wp:extrachill/artist-creator /-->`). This keeps live numbers out of stored content (honesty rule) and self-updating.

## NetworkStats keys consumed

Single guarded call to `ec_get_network_stats([...])` with real provider keys verified against `extrachill-multisite` `origin/main`:
- `events_count` + `events_cities` → Live Music Calendar → events.extrachill.com
- `community_members` + `community_topics` → The Community → community.extrachill.com
- `wire_posts` → Festival Wire → wire.extrachill.com
- `artist_profiles` → Artist Platform → artist.extrachill.com
- `total_posts` → The Publication → the blog

Each metric is read through the `{key,label,value,available}` envelope and only shown when `available === true` with a numeric value (honors the "never a fabricated zero" rule). Pluralization is value-aware (`1 dispatch` / `2 dispatches`).

## function_exists / graceful-degradation guards

- `ec_get_network_stats` is guarded with `function_exists()`; absent → cards render **label + link only**, page never fatals.
- Per-metric `available` checks drop any unavailable number while keeping the card.
- `ec_get_site_url` guarded with `function_exists()` + hardcoded subsite-URL fallbacks.
- Verified via stubbed smoke runs: full-stats render, mixed-availability (unavailable `community_topics` dropped cleanly), and **no-multisite-helpers** degrade — all pass, no fatals.

## Additive + router, not a homepage

- New slug, new page; homepage and existing pages/routing untouched.
- The page LINKS out to the live subsites; it embeds no cross-blog functional blocks.
- The link-page footer re-aim (artist-platform#76) is intentionally **not** touched here.

## #artists anchor for the future footer re-aim

The artist conversion section is a `<section id="artists">` (`"anchor":"artists"`) with the benefit stack (free link page at extrachill.link, own forum, sell merch, get discovered, analytics) and a CTA deep-linking to `artist.extrachill.com/login/#tab-register`, so the future footer re-aim can target `#artists` directly.

## Verification

- `php -l` clean on all changed files.
- `phpcs --standard=WordPress` clean (0/0) on `extrachill-blog.php` + `inc/power/` (the 2 pre-existing findings in `inc/core/admin-customizations.php` are untouched and unrelated).
- Stubbed smoke tests for composition + network-map render + full graceful degradation all pass.

Closes #16