### PR TITLE
fix: correct /power artist benefits (forum + merch overstatement)

### DIFF
--- a/inc/power/network-map-block.php
+++ b/inc/power/network-map-block.php
@@ -231,7 +231,7 @@ function extrachill_blog_render_network_map_block() {
 		),
 		array(
 			'title' => __( 'Artist Platform', 'extrachill-blog' ),
-			'desc'  => __( 'Free link pages, forums, and merch tools for independent artists to run their own corner.', 'extrachill-blog' ),
+			'desc'  => __( 'Free link pages, subscribers, and analytics for independent artists to run their own corner.', 'extrachill-blog' ),
 			'url'   => $site_url( 'artist', 'https://artist.extrachill.com' ),
 			'cta'   => __( 'Explore the platform', 'extrachill-blog' ),
 			'proof' => extrachill_blog_network_proof_line(

--- a/inc/power/power-page.php
+++ b/inc/power/power-page.php
@@ -153,7 +153,7 @@ HTML;
 
 	$pillar_platform = extrachill_blog_power_pillar(
 		'The Power of the Platform',
-		'Every independent artist gets a free home base: a link page at extrachill.link, their own forum, merch tools, and analytics. You own your corner — we just hand you the keys and get out of the way.',
+		'Every independent artist gets a free home base: a link page at extrachill.link, your own subscribers, and analytics. You own your corner — we just hand you the keys and get out of the way.',
 		'Build your home base',
 		$artist_register_url
 	);
@@ -183,11 +183,7 @@ HTML;
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li>Your own forum to talk directly with fans.</li>
-<!-- /wp:list-item -->
-
-<!-- wp:list-item -->
-<li>Tools to sell merch on your terms.</li>
+<li>Build a subscriber list so you can reach fans directly.</li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->


### PR DESCRIPTION
## Summary

The squash-merge of #17 captured an **early** commit on the branch, so the corrected artist-benefit copy never landed on `main`. The live `/power` page currently overstates what artists get.

This PR re-applies the two corrections (verified against live code):

- **No per-artist forum.** Artists do not get their own forum. Removed from the platform pillar and the artist benefit list.
- **Merch/shop is rollout-gated, not generally available.** `ec_can_manage_shop()` (extrachill-users) requires `ec_feature_available( 'shop', $user_id )` on top of owning an artist profile — it is behind a feature rollout. Advertising "sell merch" as a current benefit overpromises. Removed.

Replaced with the **live, ungated** artist benefits, confirmed in code:
- **Link page** at extrachill.link (live)
- **Subscribers** — subscribe modal/inline form + subscriber DB + list/export abilities, no feature gate
- **Analytics** — link-page analytics tables, gated only on "has a link page"

Also removed a duplicate "Get discovered" list item introduced by the swap.

The Community pillar's "forums" reference is intentionally **kept** — that is the live community.extrachill.com bbPress forum, not an artist feature.

## Verification
- `php -l` clean on both changed files
- `phpcs --standard=WordPress inc/power/` clean (0/0)
- Grep confirms no remaining `merch` / `sell` / "own forum" claims; `forum` appears once (community pillar)

Follow-up to #17.