### PR TITLE
fix: remove inherited accent h2 underline from /power headings

### DIFF
--- a/assets/css/power.css
+++ b/assets/css/power.css
@@ -16,6 +16,20 @@
 	color: var(--text-color);
 }
 
+/*
+ * The article content style `.entry-content h2 { border-bottom: 2px solid
+ * var(--accent) }` (single-post.css) is meant for long-form posts, not this
+ * manifesto. Remove that accent underline from the page's headings — the
+ * higher specificity (.entry-content .power-page) wins without !important.
+ */
+.entry-content .power-page h1,
+.entry-content .power-page h2,
+.entry-content .power-page h3 {
+	border-bottom: none;
+	padding-bottom: 0;
+	width: auto;
+}
+
 /* ---- Hero ---- */
 
 .power-hero {


### PR DESCRIPTION
## Summary

Follow-up polish to the /power dark-mode rewrite (#19). **Only changes `assets/css/power.css`.**

`single-post.css` applies an accent underline to article headings:

```css
.entry-content h2 { border-bottom: 2px solid var(--accent); padding-bottom: var(--spacing-sm); width: fit-content; }
```

That stylesheet also loads on `/power`, so the manifesto section headings — and the `h2`/`h3` headings nested **inside** the pillar and network cards — were getting a green underline that looks wrong in the card context.

## Fix

Scoped override (higher specificity via `.entry-content .power-page`, no `!important`):

```css
.entry-content .power-page h1,
.entry-content .power-page h2,
.entry-content .power-page h3 {
  border-bottom: none;
  padding-bottom: 0;
  width: auto;
}
```

Also resets `padding-bottom` and the `width: fit-content` (which would shrink the centered section headings).

Follow-up to #19.