### PR TITLE
fix: pillar titles h3 so they don't inherit the section-heading underline

### DIFF
--- a/assets/css/power.css
+++ b/assets/css/power.css
@@ -16,20 +16,6 @@
 	color: var(--text-color);
 }
 
-/*
- * The article content style `.entry-content h2 { border-bottom: 2px solid
- * var(--accent) }` (single-post.css) is meant for long-form posts, not this
- * manifesto. Remove that accent underline from the page's headings — the
- * higher specificity (.entry-content .power-page) wins without !important.
- */
-.entry-content .power-page h1,
-.entry-content .power-page h2,
-.entry-content .power-page h3 {
-	border-bottom: none;
-	padding-bottom: 0;
-	width: auto;
-}
-
 /* ---- Hero ---- */
 
 .power-hero {

--- a/inc/power/power-template.php
+++ b/inc/power/power-template.php
@@ -140,7 +140,7 @@ function extrachill_blog_power_pillar( $heading, $statement, $cta_label, $cta_ur
 	ob_start();
 	?>
 	<div class="power-pillar">
-		<h2 class="power-pillar__title"><?php echo esc_html( $heading ); ?></h2>
+		<h3 class="power-pillar__title"><?php echo esc_html( $heading ); ?></h3>
 		<p class="power-pillar__statement"><?php echo esc_html( $statement ); ?></p>
 		<a class="button-1 button-medium power-pillar__cta" href="<?php echo esc_url( $cta_url ); ?>"><?php echo esc_html( $cta_label ); ?></a>
 	</div>


### PR DESCRIPTION
## Summary

Better fix for the card-heading underline (replaces the CSS override from #21).

The accent underline (`.entry-content h2` from single-post.css) looks **right** on the page's section headings ("The power of staying independent", "One network, many doors") — keep it there. It looked **wrong** on the pillar cards.

Instead of overriding CSS, demote the in-card heading semantics:
- **Pillar titles: `h2` → `h3`** (network card titles were already `h3`)
- **Removed** the `.entry-content .power-page` border override added in #21

Now the underline naturally applies only to the section `h2`s and not to the `h3` card titles — no override needed. Heading hierarchy stays valid: `h1` hero → `h2` sections → `h3` card titles. `.power-pillar__title` styling is class-based, so it's unaffected by the tag change.

Follow-up to #21.