### PR TITLE
fix: center /power section headings + sharpen pillar copy

### DIFF
--- a/assets/css/power.css
+++ b/assets/css/power.css
@@ -49,7 +49,13 @@
 }
 
 .power-section__heading {
-	margin: 0 0 var(--spacing-sm);
+	/*
+	 * single-post.css gives `.entry-content h2` `width: fit-content`, which
+	 * shrinks the underlined box to the text width and pins it left. Center the
+	 * shrunk box so the accent underline hugs the text AND sits centered.
+	 */
+	margin: 0 auto var(--spacing-sm);
+	width: fit-content;
 	text-align: center;
 	font-family: var(--font-family-heading);
 	font-size: var(--font-size-2xl);

--- a/inc/power/power-template.php
+++ b/inc/power/power-template.php
@@ -281,8 +281,8 @@ function extrachill_blog_power_manifesto_html() {
 	$pillars = array(
 		extrachill_blog_power_pillar(
 			__( 'The Power of Independent Music', 'extrachill-blog' ),
-			__( 'Independent artists make the music that actually moves the scene forward. We cover it, calendar it, and point fans straight at it — no major-label gatekeeping, no pay-to-play. The music comes first, every time.', 'extrachill-blog' ),
-			__( 'See what\'s playing', 'extrachill-blog' ),
+			__( 'Our live music calendar tracks independent shows and festivals across the country — pulled from real venue listings, city by city. No major-label gatekeeping, no pay-to-play placement. Just a straight answer to "who\'s playing near me?"', 'extrachill-blog' ),
+			__( 'Browse the calendar', 'extrachill-blog' ),
 			$events_url
 		),
 		extrachill_blog_power_pillar(
@@ -299,7 +299,7 @@ function extrachill_blog_power_manifesto_html() {
 		),
 		extrachill_blog_power_pillar(
 			__( 'The Power of Staying Independent', 'extrachill-blog' ),
-			__( 'Since 2011, out of a Charleston dorm room. We stand by our core philosophies and never give in to corporate pressure or aggressive monetization. Sustainable, memorable, and built on the spirit of the music — not on getting rich.', 'extrachill-blog' ),
+			__( 'Since 2011, out of a Charleston dorm room. We stand by our core philosophies and never give in to corporate pressure or aggressive monetization. Sustainable, memorable, and built on the spirit of the music.', 'extrachill-blog' ),
 			__( 'Read our long-term vision', 'extrachill-blog' ),
 			home_url( '/long-term-vision/' )
 		),


### PR DESCRIPTION
## Summary

Polish + copy fixes for /power:

- **Center the underlined section headings.** `single-post.css` gives `.entry-content h2` `width: fit-content`, which shrank the centered section headings and pinned them left. Add `width: fit-content; margin-inline: auto` so the accent underline hugs the text **and** the box sits centered.
- **Sharpen the "Power of Independent Music" pillar.** Replaced the vague "we cover it, calendar it, and point fans straight at it" with concrete copy about the live music calendar (independent shows + festivals, pulled from real venue listings, city by city). CTA changed to "Browse the calendar".
- **Drop "— not on getting rich"** from the "Staying Independent" pillar.

Follow-up to #22.