### PR TITLE
fix: remove false 'independent / not ad buys' claims from /power calendar copy

### DIFF
--- a/inc/power/power-template.php
+++ b/inc/power/power-template.php
@@ -159,7 +159,7 @@ function extrachill_blog_power_network_map() {
 	$cards = array(
 		array(
 			'title' => __( 'Live Music Calendar', 'extrachill-blog' ),
-			'desc'  => __( 'Independent shows and festivals, city by city — built from venue listings, not ad buys.', 'extrachill-blog' ),
+			'desc'  => __( 'Shows and festivals across the country, city by city — free to browse, no login wall.', 'extrachill-blog' ),
 			'url'   => extrachill_blog_power_site_url( 'events', 'https://events.extrachill.com' ),
 			'cta'   => __( 'Browse the calendar', 'extrachill-blog' ),
 			'proof' => extrachill_blog_power_proof_line(
@@ -281,7 +281,7 @@ function extrachill_blog_power_manifesto_html() {
 	$pillars = array(
 		extrachill_blog_power_pillar(
 			__( 'The Power of Independent Music', 'extrachill-blog' ),
-			__( 'Our live music calendar tracks independent shows and festivals across the country — pulled from real venue listings, city by city. No major-label gatekeeping, no pay-to-play placement. Just a straight answer to "who\'s playing near me?"', 'extrachill-blog' ),
+			__( 'Our live music calendar pulls together shows and festivals from across the country — ticketing platforms and venue listings alike, city by city. Free to browse, no login wall, no algorithm deciding what you see. Just a straight answer to "who\'s playing near me?"', 'extrachill-blog' ),
 			__( 'Browse the calendar', 'extrachill-blog' ),
 			$events_url
 		),


### PR DESCRIPTION
## Summary

The /power calendar copy made claims that don't match the actual data:

- ❌ "**independent** shows and festivals"
- ❌ "built from **venue listings, not ad buys**"

**Reality (prod data):** the live calendar is dominated by **Ticketmaster** and **Dice.fm** ticketing-API events, many carrying affiliate ticket links. **84% of upcoming events (32,324 of 38,331) have a `_datamachine_ticket_url`.** The direct venue web-scraper is the minority long-tail. So the calendar is comprehensive, not curated-to-independent, and it's mostly ticketing-sourced — the opposite of "venue listings, not ad buys."

(Extra Chill's *ethos* is independent; the *calendar contents* are not independent-only. Stating otherwise on a credibility-driven manifesto page is a false claim.)

## Fix — claim only what's true and still compelling

**Independent Music pillar:**
> Our live music calendar pulls together shows and festivals from across the country — ticketing platforms and venue listings alike, city by city. Free to browse, no login wall, no algorithm deciding what you see. Just a straight answer to "who's playing near me?"

**Events network-map card:**
> Shows and festivals across the country, city by city — free to browse, no login wall.

Verified true: comprehensive multi-source (Ticketmaster + Dice + venue scrape), free, and **chronological** ("no algorithm deciding what you see" — confirmed `CalendarAbilities` uses `ORDER BY start_date ASC`, no ranking).

## Audit of other page claims (all hold up)
- "open-source" — repos are public ✓
- Community forums + upvotes ✓
- Artist: link page + subscribers + analytics ✓ (merch already removed as rollout-gated)
- "Since 2011, Charleston dorm room" ✓

Follow-up to #24.