### PR TITLE
feat: add open-source/engineering door to /power + fix broken vision CTA

### DIFF
--- a/inc/power/power-template.php
+++ b/inc/power/power-template.php
@@ -247,6 +247,13 @@ function extrachill_blog_power_network_map() {
 				)
 			),
 		),
+		array(
+			'title' => __( 'The Open-Source Platform', 'extrachill-blog' ),
+			'desc'  => __( 'The whole network is open source — and increasingly built and operated by AI agents we direct in plain language, live on the server. Peek under the hood.', 'extrachill-blog' ),
+			'url'   => 'https://github.com/Extra-Chill',
+			'cta'   => __( 'See the code on GitHub', 'extrachill-blog' ),
+			'proof' => '',
+		),
 	);
 
 	ob_start();
@@ -300,8 +307,8 @@ function extrachill_blog_power_manifesto_html() {
 		extrachill_blog_power_pillar(
 			__( 'The Power of Staying True', 'extrachill-blog' ),
 			__( 'Since 2011, out of a Charleston dorm room. We stand by our core philosophies and never give in to corporate pressure or aggressive monetization. Sustainable, memorable, and built on the spirit of the music.', 'extrachill-blog' ),
-			__( 'Read our long-term vision', 'extrachill-blog' ),
-			home_url( '/long-term-vision/' )
+			__( 'Read our story', 'extrachill-blog' ),
+			home_url( '/about/' )
 		),
 	);
 


### PR DESCRIPTION
## Summary

Two changes to /power:

### 1. New 6th network-map card: "The Open-Source Platform"
Adds an opt-in door to the engineering side of Extra Chill — linking to **github.com/Extra-Chill** — framed as:
> The whole network is open source — and increasingly built and operated by AI agents we direct in plain language, live on the server. Peek under the hood.

This leans into the genuinely-rare angle (a music publication that's also a live, agent-operated open-source project) **without hijacking the music message**: it's a destination for the builders/curious, not a headline that confuses fans. The grid is `repeat(3, ...)` so 6 cards form a clean 2×3. No proof number (handled by the existing `! empty($card['proof'])` guard).

### 2. Fix broken "long-term vision" CTA
The "Staying True" pillar CTA pointed at `/long-term-vision/`, which is an **unpublished draft (404s)** and is **outdated**. Retargeted to **/about/** — published, verified 200, and it already tells the open-source + AI-agents story in EC's own voice ("AI agents help us run the whole thing... a weird and novel setup for a music publication, and we think that's the point"). Label changed to "Read our story".

## Verification
- `php -l` + `phpcs --standard=WordPress inc/power/` clean (0/0)
- All page destinations return 200: /about/, artist login, events/community/wire roots, github.com/Extra-Chill
- Render check: 6 cards, GitHub door present, no empty proof line

Follow-up to #26.