### PR TITLE
fix: differentiate /power hero from homepage + fix stale Austin location

### DIFF
--- a/inc/home/templates/section-about.php
+++ b/inc/home/templates/section-about.php
@@ -10,7 +10,7 @@
 <div class="home-network-card" aria-labelledby="about-header">
 	<h2 class="home-network-card-header" id="about-header">About Extra Chill</h2>
 	<div class="home-network-card-description">
-		Founded in 2011 in Charleston, SC, and now local to Austin, TX, Extra Chill is an open-source, independent music platform. We value storytelling and believe in the power of community. Our platform is a meeting ground for artists, fans, and music industry professionals.
+		Founded in 2011 in Charleston, SC, Extra Chill is an open-source, independent music platform. We value storytelling and believe in the power of community. Our platform is a meeting ground for artists, fans, and music industry professionals.
 	</div>
 	<div class="home-network-card-cta">
 		<a href="/about" class="button-2 button-medium">Learn More</a>

--- a/inc/power/power-template.php
+++ b/inc/power/power-template.php
@@ -324,8 +324,8 @@ function extrachill_blog_power_manifesto_html() {
 	<div class="power-page">
 
 		<header class="power-hero">
-			<h1 class="power-hero__title"><?php esc_html_e( 'Extra Chill is the online music scene.', 'extrachill-blog' ); ?></h1>
-			<p class="power-hero__lede"><?php esc_html_e( 'Not just a blog — an independent, open-source music network. A live calendar, a community of musicians and fans, a festival news wire, and free tools for artists to run their own corner. All grassroots, all independent, no astro-turf.', 'extrachill-blog' ); ?></p>
+			<h1 class="power-hero__title"><?php esc_html_e( 'Extra Chill is not a blog. It\'s a whole network.', 'extrachill-blog' ); ?></h1>
+			<p class="power-hero__lede"><?php esc_html_e( 'Most people find us through one article and never realize what\'s underneath: an independent, open-source music network. A live concert calendar, a community of musicians and fans, a festival news wire, and free tools for artists to run their own corner. All grassroots, all independent, no astro-turf.', 'extrachill-blog' ); ?></p>
 			<a class="button-1 button-large power-hero__cta" href="<?php echo esc_url( $community_url ); ?>"><?php esc_html_e( 'Join the community', 'extrachill-blog' ); ?></a>
 		</header>
 


### PR DESCRIPTION
## Summary

Keeps /power and the homepage "different enough to coexist" (the original plan), and fixes a stale-location bug.

### 1. Differentiate the /power hero
The /power hero echoed the homepage's catchphrase ("Extra Chill is the online music scene" vs the homepage's "Join the Online Music Scene") — reading like a copy-paste to anyone who hit both. Reframed around /power's actual job:

> **Extra Chill is not a blog. It's a whole network.**
> Most people find us through one article and never realize what's underneath: an independent, open-source music network. A live concert calendar, a community of musicians and fans, a festival news wire, and free tools for artists to run their own corner. All grassroots, all independent, no astro-turf.

Now the two surfaces are clearly distinct: homepage = daily entry point (posts, search, browse); /power = one-shot "what is all this?" manifesto/router.

### 2. Fix stale homepage About copy
Homepage About card said "Founded in 2011 in Charleston, SC, **and now local to Austin, TX**" — stale (moved back to Charleston April 2026; /about/ already reflects this). Removed the Austin clause.

## Verification
- `php -l` + `phpcs --standard=WordPress` clean on both files