### PR TITLE
refactor: own login/register CTA placement via theme hook (#30)

### DIFF
--- a/extrachill-blog.php
+++ b/extrachill-blog.php
@@ -36,6 +36,7 @@ require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/blog-archive-routing.php'
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/breadcrumbs.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/share-card.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/network-bridge.php';
+require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/login-register-cta.php';
 
 /**
  * Register plugin styles

--- a/inc/single/login-register-cta.php
+++ b/inc/single/login-register-cta.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Login / Register CTA — Single Post Bridge (thin consumer)
+ *
+ * Surfaces the membership login/register affordance to logged-out readers on
+ * single posts, just above the comments section. This is the PLACEMENT decision
+ * for that CTA — it belongs to the site-specific blog plugin, NOT to the shared
+ * theme.
+ *
+ * The block itself (`extrachill/login-register`) is owned and registered by the
+ * extrachill-users plugin. This file only decides WHEN and WHERE it renders by
+ * hooking a theme-exposed single-article action, mirroring the pattern in
+ * network-bridge.php exactly. The theme stays generic: it exposes hooks; the
+ * feature plugins decide what fills them.
+ *
+ * @package ExtraChillBlog
+ * @since 0.7.2
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Render the "Login or Register to Comment" CTA on single posts.
+ *
+ * Hooked on `extrachill_before_comments_template` so it renders just above the
+ * comments section inside the post aside, keeping the membership affordance in
+ * its natural comment context — but plugin-owned rather than hardcoded in the
+ * theme.
+ *
+ * Guards:
+ * - Single `post` views only.
+ * - Logged-out readers only (logged-in users get the native comment form, which
+ *   the theme's comments template still renders).
+ * - Renders nothing if the login-register block is not registered (extrachill-users
+ *   inactive), so the theme never depends on a feature plugin being present.
+ */
+function extrachill_blog_login_register_cta() {
+	if ( ! is_singular( 'post' ) ) {
+		return;
+	}
+
+	if ( is_user_logged_in() ) {
+		return;
+	}
+
+	if ( ! function_exists( 'do_blocks' ) || ! class_exists( 'WP_Block_Type_Registry' ) ) {
+		return;
+	}
+
+	if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'extrachill/login-register' ) ) {
+		return;
+	}
+
+	echo '<h3>' . esc_html__( 'Login or Register to Comment', 'extrachill-blog' ) . '</h3>';
+	echo do_blocks( '<!-- wp:extrachill/login-register /-->' );
+}
+add_action( 'extrachill_before_comments_template', 'extrachill_blog_login_register_cta' );


### PR DESCRIPTION
## Summary

Fixes the layer violation in Extra-Chill/extrachill-blog#30 where the **generic shared `extrachill` theme** hardcoded a feature-plugin block into its comment template:

```php
// extrachill/inc/single/comments.php:142-143 (theme)
echo '<h3>Login or Register to Comment</h3>';
echo do_blocks( '<!-- wp:extrachill/login-register /-->' );
```

A generic theme reaching up to embed an `extrachill-users` block is the violation. This PR relocates the **placement decision** down to the site-specific `extrachill-blog` plugin, where it belongs — mirroring the existing `inc/single/network-bridge.php` pattern exactly.

## What changed (plugin-side, this PR)

- **New `inc/single/login-register-cta.php`** — a thin consumer that hooks the CTA onto a theme-exposed single-article action and defers rendering to the canonical block.
  - **Hook used:** `extrachill_before_comments_template` (fired in the theme's `inc/single/single-post.php:56`, inside the post `<aside>` directly above the comments section). This keeps the membership affordance in its natural comment context while making it plugin-owned.
  - **Mirrors `network-bridge.php`:** same shape — guard to single `post` views, defer to the canonical surface (here the `extrachill/login-register` block registered by `extrachill-users`), render nothing when prerequisites are absent.
  - **Guards:** single `post` only; **logged-out readers only** (logged-in users still get the native comment form from the theme); and a `WP_Block_Type_Registry::is_registered( 'extrachill/login-register' )` check so the theme/plugin never hard-depends on `extrachill-users` being active (no fatal, no empty markup if the block is gone).
- **`extrachill-blog.php`** — `require_once` the new file alongside `network-bridge.php`.

The block registration stays in `extrachill-users` (not moved). The plugin owns only the **placement**, exactly as the issue directs.

## Layer purity

This restores the correct direction of dependency: the theme exposes hooks (`extrachill_before_comments_template`, `extrachill_after_post_content`, …); feature/site plugins decide what fills them. The theme no longer needs to know the `extrachill/login-register` block exists.

## ⚠ Paired theme change required (separate follow-up — NOT in this PR)

This PR must land **together with** a theme PR, or the CTA will render **twice** (once from the theme hardcode, once from this new hook).

**Required theme edit** — in repo `Extra-Chill/extrachill` (theme), file `inc/single/comments.php`, remove the hardcoded logged-out branch at **lines 142-143**:

```php
} else {
    echo '<h3>' . __( 'Login or Register to Comment', 'extrachill' ) . '</h3>';   // remove
    echo do_blocks( '<!-- wp:extrachill/login-register /-->' );                    // remove
}
```

After removal, the theme's `else` branch should render nothing (or just be dropped) — the plugin hook now supplies the CTA above the comments section. The logged-in `comment_form()` branch (lines 132-140) is untouched and still renders the comment form, so commenting is unaffected.

I did **not** edit the theme from this worktree (only an `extrachill-blog` worktree was available, and the theme is read-only here). Flagging it as a required paired follow-up PR.

## Verification

- `php -l inc/single/login-register-cta.php` → clean
- `php -l extrachill-blog.php` → clean

## Notes

- Copy/placement strategy was intentionally **not** redesigned — this is a clean ownership relocation only, per the issue (`<h3>Login or Register to Comment</h3>` heading preserved verbatim).

Refs Extra-Chill/extrachill-blog#30