### PR TITLE
fix: make responsive card grids overflow-safe (min(100%, floor))

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -242,7 +242,7 @@
 
 .home-network-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
     gap: var(--spacing-xl);
     justify-content: center;
     max-width: var(--container-wide);


### PR DESCRIPTION
## Summary

Adopts the overflow-safe `min(100%, <floor>)` card-grid pattern from Extra-Chill/extrachill-components#16 locally in extrachill-blog — **without** adding any dependency on the shared `@extrachill/components` stylesheet (extrachill-blog does not load it).

## Grids fixed

- `assets/css/home.css` (`.home-network-grid`, line 245): `minmax(280px, 1fr)` → `minmax(min(100%, 280px), 1fr)`

Minimal safe win: prevents horizontal overflow when the viewport is narrower than the 280px floor; layout is identical otherwise. `auto-fit`, `gap`, floor value, and all media-query overrides are unchanged.

## Verification

- Only one hand-rolled grid in the plugin (`grep 'repeat(auto-f'`).
- CSS is plain (no package.json, no CSS build step in `build.sh`) — ships as-is, no rebuild needed.
- Diff is surgical (1 line), CSS remains valid.

Refs #16