### PR TITLE
feat: prioritize users' default event market

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "lint:php": "vendor/bin/phpcs --standard=WordPress *.php inc/",
         "lint:fix": "vendor/bin/phpcbf --standard=WordPress *.php inc/",
         "test": [
+            "php tests/homepage-event-markets.php",
             "@lint:php"
         ]
     },

--- a/inc/home/homepage-queries.php
+++ b/inc/home/homepage-queries.php
@@ -23,19 +23,58 @@ $latest_blog_posts = get_posts(
 /**
  * Get location terms with upcoming event counts from events.extrachill.com
  *
- * Uses internal REST API call to get top 8 locations with upcoming events,
- * sorted by event count descending.
+ * Uses the existing user-settings and upcoming-counts contracts to put an
+ * authenticated user's preferred market first. All failures retain the global
+ * top-eight response.
  *
  * @return array Array of location data: name, slug, count, url
  */
 function extrachill_blog_get_location_event_counts() {
-	$request = new WP_REST_Request( 'GET', '/extrachill/v1/events/upcoming-counts' );
-	$request->set_query_params(
+	$locations = extrachill_blog_request_location_event_counts(
 		array(
 			'taxonomy' => 'location',
 			'limit'    => 8,
 		)
 	);
+
+	if ( empty( $locations ) ) {
+		return array();
+	}
+
+	$preferred_slug = extrachill_blog_get_default_event_location_slug();
+	if ( '' === $preferred_slug ) {
+		return $locations;
+	}
+
+	foreach ( $locations as $location ) {
+		if ( isset( $location['slug'] ) && $preferred_slug === $location['slug'] ) {
+			return extrachill_blog_prioritize_event_market( $locations, $location );
+		}
+	}
+
+	$preferred = extrachill_blog_request_location_event_counts(
+		array(
+			'taxonomy' => 'location',
+			'slug'     => $preferred_slug,
+		)
+	);
+
+	if ( empty( $preferred[0] ) ) {
+		return $locations;
+	}
+
+	return extrachill_blog_prioritize_event_market( $locations, $preferred[0] );
+}
+
+/**
+ * Request upcoming location counts through the existing network REST contract.
+ *
+ * @param array $query Query parameters accepted by upcoming-counts.
+ * @return array[] Location count rows.
+ */
+function extrachill_blog_request_location_event_counts( $query ) {
+	$request = new WP_REST_Request( 'GET', '/extrachill/v1/events/upcoming-counts' );
+	$request->set_query_params( $query );
 
 	$response = rest_do_request( $request );
 
@@ -45,6 +84,72 @@ function extrachill_blog_get_location_event_counts() {
 
 	$data = $response->get_data();
 	return is_array( $data ) ? $data : array();
+}
+
+/**
+ * Read the authenticated user's canonical default event location.
+ *
+ * The preference is supplied by extrachill-users#176 through the existing
+ * self-only settings Ability. Until that dependency is available, or whenever
+ * its result is unavailable, this intentionally fails open to global markets.
+ *
+ * @return string Canonical location slug, or an empty string.
+ */
+function extrachill_blog_get_default_event_location_slug() {
+	if (
+		! is_user_logged_in() ||
+		! function_exists( 'wp_has_ability' ) ||
+		! function_exists( 'wp_get_ability' ) ||
+		! wp_has_ability( 'extrachill/get-user-settings' )
+	) {
+		return '';
+	}
+
+	$ability = wp_get_ability( 'extrachill/get-user-settings' );
+	if ( ! $ability ) {
+		return '';
+	}
+
+	$settings = $ability->execute( array() );
+	if ( is_wp_error( $settings ) || ! is_array( $settings ) ) {
+		return '';
+	}
+
+	$location = $settings['default_event_location'] ?? null;
+	if ( ! is_array( $location ) || empty( $location['slug'] ) ) {
+		return '';
+	}
+
+	return sanitize_title( $location['slug'] );
+}
+
+/**
+ * Lead market rows with a preferred location and remove duplicate slugs.
+ *
+ * @param array[] $locations Global market rows.
+ * @param array   $preferred Preferred market row.
+ * @return array[] At most eight market rows.
+ */
+function extrachill_blog_prioritize_event_market( $locations, $preferred ) {
+	if ( empty( $preferred['slug'] ) ) {
+		return array_slice( $locations, 0, 8 );
+	}
+
+	$preferred_slug = (string) $preferred['slug'];
+	$prioritized    = array( $preferred );
+
+	foreach ( $locations as $location ) {
+		if ( empty( $location['slug'] ) || $preferred_slug === (string) $location['slug'] ) {
+			continue;
+		}
+
+		$prioritized[] = $location;
+		if ( 8 === count( $prioritized ) ) {
+			break;
+		}
+	}
+
+	return $prioritized;
 }
 
 /**

--- a/inc/home/homepage-queries.php
+++ b/inc/home/homepage-queries.php
@@ -89,9 +89,11 @@ function extrachill_blog_request_location_event_counts( $query ) {
 /**
  * Read the authenticated user's canonical default event location.
  *
- * The preference is supplied by extrachill-users#176 through the existing
- * self-only settings Ability. Until that dependency is available, or whenever
- * its result is unavailable, this intentionally fails open to global markets.
+ * The preference is supplied by extrachill-users#179 through the existing
+ * self-only settings Ability. Its resolved object is canonicalized by the
+ * Events-owned extrachill/events-locations Ability; this consumer does not
+ * repeat taxonomy validation. Unavailable or malformed data intentionally
+ * fails open to global markets.
  *
  * @return string Canonical location slug, or an empty string.
  */
@@ -120,7 +122,7 @@ function extrachill_blog_get_default_event_location_slug() {
 		return '';
 	}
 
-	return sanitize_title( $location['slug'] );
+	return (string) $location['slug'];
 }
 
 /**

--- a/tests/homepage-event-markets.php
+++ b/tests/homepage-event-markets.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Focused tests for homepage event-market ordering.
+ *
+ * Run with: php tests/homepage-event-markets.php
+ */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+$test_logged_in = false;
+$test_settings  = array();
+
+function get_posts() {
+	return array();
+}
+
+function is_user_logged_in() {
+	global $test_logged_in;
+	return $test_logged_in;
+}
+
+function wp_has_ability( $name ) {
+	return 'extrachill/get-user-settings' === $name;
+}
+
+function wp_get_ability( $name ) {
+	return new class() {
+		public function execute() {
+			global $test_settings;
+			return $test_settings;
+		}
+	};
+}
+
+function is_wp_error() {
+	return false;
+}
+
+function sanitize_title( $slug ) {
+	return strtolower( trim( preg_replace( '/[^a-z0-9]+/i', '-', $slug ), '-' ) );
+}
+
+require_once dirname( __DIR__ ) . '/inc/home/homepage-queries.php';
+
+function assert_same( $expected, $actual, $message ) {
+	if ( $expected !== $actual ) {
+		fwrite( STDERR, $message . "\n" );
+		exit( 1 );
+	}
+}
+
+$global = array();
+for ( $index = 1; $index <= 8; ++$index ) {
+	$global[] = array(
+		'slug'  => 'market-' . $index,
+		'name'  => 'Market ' . $index,
+		'count' => 10 - $index,
+	);
+}
+
+$existing = array(
+	'slug'  => 'market-3',
+	'name'  => 'Market 3',
+	'count' => 7,
+);
+$result   = extrachill_blog_prioritize_event_market( $global, $existing );
+
+assert_same( 'market-3', $result[0]['slug'], 'Existing preferred market should move to the front.' );
+assert_same( 8, count( $result ), 'Existing preferred market should preserve eight rows.' );
+assert_same( 1, count( array_filter( $result, fn( $row ) => 'market-3' === $row['slug'] ) ), 'Existing preferred market should not be duplicated.' );
+
+$outside = array(
+	'slug'  => 'preferred-market',
+	'name'  => 'Preferred Market',
+	'count' => 2,
+);
+$result  = extrachill_blog_prioritize_event_market( $global, $outside );
+
+assert_same( 'preferred-market', $result[0]['slug'], 'Outside preferred market should lead the list.' );
+assert_same( 8, count( $result ), 'Outside preferred market should replace the eighth global row.' );
+assert_same( 'market-7', $result[7]['slug'], 'Global order should be retained after the preferred market.' );
+
+$result = extrachill_blog_prioritize_event_market( $global, array() );
+assert_same( $global, $result, 'Missing preference should retain global markets unchanged.' );
+
+assert_same( '', extrachill_blog_get_default_event_location_slug(), 'Anonymous requests should not read a preference.' );
+
+$test_logged_in = true;
+$test_settings  = array();
+assert_same( '', extrachill_blog_get_default_event_location_slug(), 'Missing dependency field should fail open.' );
+
+$test_settings = array(
+	'default_event_location' => array(
+		'slug' => 'New York, NY',
+	),
+);
+assert_same( 'new-york-ny', extrachill_blog_get_default_event_location_slug(), 'Canonical preference slug should be sanitized.' );
+
+fwrite( STDOUT, "Homepage event-market tests passed.\n" );

--- a/tests/homepage-event-markets.php
+++ b/tests/homepage-event-markets.php
@@ -36,10 +36,6 @@ function is_wp_error() {
 	return false;
 }
 
-function sanitize_title( $slug ) {
-	return strtolower( trim( preg_replace( '/[^a-z0-9]+/i', '-', $slug ), '-' ) );
-}
-
 require_once dirname( __DIR__ ) . '/inc/home/homepage-queries.php';
 
 function assert_same( $expected, $actual, $message ) {
@@ -91,9 +87,9 @@ assert_same( '', extrachill_blog_get_default_event_location_slug(), 'Missing dep
 
 $test_settings = array(
 	'default_event_location' => array(
-		'slug' => 'New York, NY',
+		'slug' => 'new-york-city',
 	),
 );
-assert_same( 'new-york-ny', extrachill_blog_get_default_event_location_slug(), 'Canonical preference slug should be sanitized.' );
+assert_same( 'new-york-city', extrachill_blog_get_default_event_location_slug(), 'Resolved canonical preference slug should pass through unchanged.' );
 
 fwrite( STDOUT, "Homepage event-market tests passed.\n" );


### PR DESCRIPTION
## Summary
- lead `Top Event Markets` with an authenticated user's resolved canonical default location and its live upcoming count
- retain global market ordering for anonymous users, users without a preference, and every dependency/error fallback
- fill the remaining eight slots from global top markets while deduplicating by canonical slug
- rebase onto latest `main` without changing PR #40's six-card network grid or Recently Shipped behavior

## Cache isolation
Extra Chill Cache bypasses cached HTML whenever a `wordpress_logged_in_*` cookie is present and refuses to store responses when `is_user_logged_in()` is true. Personalization therefore renders server-side only for uncached authenticated requests. Anonymous cached HTML remains the global `Top Event Markets` response and cannot contain another user's preference.

## Dependency contract and ownership
This consumes the existing self-only `extrachill/get-user-settings` Ability as revised by Extra-Chill/extrachill-users#179. The consumer expects its private `default_event_location` field to be either `null` or a resolved canonical object containing `slug`.

Canonical taxonomy resolution, hierarchy eligibility, archive URL, and coordinates belong to the merged public `extrachill/events-locations` Ability from Extra-Chill/extrachill-events#234. Users owns persistence and delegates resolution there. Blog trusts the resulting canonical slug and does not switch blogs, inspect taxonomy terms, sanitize/revalidate the slug, or duplicate Events-domain validation.

Until users#179 is available, or whenever the settings Ability/field is missing, malformed, or returns an error, the module fails open to the unchanged global top-eight response.

## Counts, fallback, and deduplication
The existing `/extrachill/v1/events/upcoming-counts` contract remains the only count source. If the canonical preferred slug already appears in the global top eight, that live row moves first. Otherwise, the same endpoint performs one single-slug count lookup. A preferred location with no upcoming row leaves the global response unchanged. Remaining rows retain global rank and duplicate slugs are omitted; no personalized-events endpoint is introduced.

## Latest-main integration
The branch is rebased on current `main` (`813f37b`), which includes PR #40. The diff does not modify `assets/css/home.css`, homepage section placement, the `Top Event Markets` label, or Recently Shipped templates/storage.

## Tests
- `php tests/homepage-event-markets.php`
- `vendor/bin/phpcs --standard=WordPress inc/home/homepage-queries.php`
- `php -l inc/home/homepage-queries.php`
- `php -l tests/homepage-event-markets.php`
- `git diff --check`

All focused/scoped checks pass. Repository-wide `composer test` remains blocked after the focused test by pre-existing PHPCS violations in unrelated files (`inc/core/co-authors.php`, `inc/core/ads-filter.php`, `inc/core/admin-customizations.php`, and `inc/single/login-register-cta.php`).

Closes #38