### PR TITLE
fix: restore recently shipped network card

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -299,7 +299,7 @@
 
 .home-network-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: var(--spacing-xl);
     justify-content: center;
     max-width: var(--container-wide);
@@ -546,43 +546,13 @@
     font-size: var(--font-size-base);
 }
 
-/*
- * Recently Shipped strip — compact, one row per release, matches the
- * visual weight of the home-3x3 sections.
- */
-.home-shipped-strip {
-    background: var(--card-background);
-    border-radius: var(--border-radius-xl);
-    box-shadow: var(--card-shadow);
-    padding: var(--spacing-md) var(--spacing-lg);
-    max-width: var(--container-wide);
-    margin: var(--spacing-xl) auto 0 auto;
-}
-
-.home-shipped-header {
-    display: flex;
-    align-items: baseline;
-    flex-wrap: wrap;
-    gap: var(--spacing-sm);
-    margin-bottom: var(--spacing-md);
-}
-
-.home-shipped-label {
-    font-family: var(--font-family-heading);
-    font-size: var(--font-size-xl);
-    font-weight: 800;
-    color: var(--accent);
-    letter-spacing: 0.03em;
-    background: var(--card-background);
-    border-left: 4px solid var(--accent);
-    padding: 0.1em var(--spacing-sm);
-    border-radius: 0 var(--border-radius-md) var(--border-radius-md) 0;
+.home-shipped-card {
+    align-items: stretch;
 }
 
 .home-shipped-kicker {
-    font-size: var(--font-size-sm);
     color: var(--muted-text);
-    font-style: italic;
+    text-align: center;
 }
 
 .home-shipped-list {
@@ -594,8 +564,9 @@
 .home-shipped-row {
     display: flex;
     align-items: center;
-    gap: var(--spacing-md);
-    padding: var(--spacing-sm) var(--spacing-md);
+    flex-wrap: wrap;
+    gap: var(--spacing-xs) var(--spacing-sm);
+    padding: var(--spacing-sm);
     background: var(--background-color);
     border-radius: var(--border-radius-lg);
     text-decoration: none;
@@ -628,7 +599,7 @@
     align-items: baseline;
     flex-wrap: wrap;
     gap: 0 var(--spacing-sm);
-    flex: 1;
+    flex: 1 1 55%;
     min-width: 0;
 }
 
@@ -654,6 +625,7 @@
     font-size: var(--font-size-sm);
     color: var(--muted-text);
     white-space: nowrap;
+    margin-left: auto;
 }
 
 .home-shipped-footer {
@@ -673,15 +645,4 @@
 .home-shipped-footer a:hover,
 .home-shipped-footer a:focus {
     color: var(--accent);
-}
-
-@media (max-width: 600px) {
-    .home-shipped-row {
-        flex-wrap: wrap;
-        gap: var(--spacing-xs) var(--spacing-sm);
-    }
-
-    .home-shipped-meta {
-        margin-left: auto;
-    }
 }

--- a/inc/home/homepage-hooks.php
+++ b/inc/home/homepage-hooks.php
@@ -36,7 +36,7 @@ function extrachill_blog_refresh_recently_shipped() {
 		return;
 	}
 
-	set_transient( 'extrachill_blog_recently_shipped_last_good', $payload, WEEK_IN_SECONDS );
+	update_option( 'extrachill_blog_recently_shipped_last_good', $payload, false );
 }
 add_action( 'extrachill_blog_refresh_recently_shipped', 'extrachill_blog_refresh_recently_shipped' );
 
@@ -49,7 +49,6 @@ function extrachill_blog_render_homepage() {
 	include EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/home/templates/hero.php';
 	include EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/home/templates/section-3x3-grid.php';
 	include EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/home/templates/section-search.php';
-	include EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/home/templates/section-recently-shipped.php';
 	?>
 	<div class="home-network-grid">
 		<?php
@@ -58,6 +57,7 @@ function extrachill_blog_render_homepage() {
 		include EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/home/templates/section-events.php';
 		include EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/home/templates/section-docs.php';
 		include EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/home/templates/section-about.php';
+		include EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/home/templates/section-recently-shipped.php';
 		?>
 	</div>
 	<?php

--- a/inc/home/homepage-queries.php
+++ b/inc/home/homepage-queries.php
@@ -95,14 +95,24 @@ function extrachill_blog_get_wire_latest( $limit = 4 ) {
  * Get the "Recently Shipped" homepage payload — recent GitHub releases
  * across the whole Extra-Chill org plus a monthly-activity stat.
  *
- * Reads only the long-TTL last-good transient populated by the scheduled
- * warmer. If no payload is available, the section renders nothing.
+ * Reads only the durable last-good option populated by the scheduled warmer.
+ * A legacy transient is migrated when present. If no payload is available,
+ * the section renders nothing.
  *
  * @return array{releases: array[], repos_active_this_month: int, repos_total: int}|array{}
  */
 function extrachill_blog_get_recently_shipped() {
-	$last_good = get_transient( 'extrachill_blog_recently_shipped_last_good' );
+	$option_name = 'extrachill_blog_recently_shipped_last_good';
+	$last_good   = get_option( $option_name, array() );
 	if ( is_array( $last_good ) && ! empty( $last_good ) ) {
+		return $last_good;
+	}
+
+	$last_good = get_transient( $option_name );
+	if ( is_array( $last_good ) && ! empty( $last_good ) ) {
+		update_option( $option_name, $last_good, false );
+		delete_transient( $option_name );
+
 		return $last_good;
 	}
 
@@ -153,7 +163,7 @@ function extrachill_blog_fetch_recently_shipped() {
 
 	foreach ( $candidate_repos as $repo_name ) {
 		$release_response = wp_remote_get(
-			sprintf( 'https://api.github.com/repos/Extra-Chill/%s/releases?per_page=1', rawurlencode( $repo_name ) ),
+			sprintf( 'https://api.github.com/repos/Extra-Chill/%s/releases/latest', rawurlencode( $repo_name ) ),
 			array(
 				'timeout' => 10,
 				'headers' => array( 'Accept' => 'application/vnd.github+json' ),
@@ -166,11 +176,11 @@ function extrachill_blog_fetch_recently_shipped() {
 
 		$release_data = json_decode( wp_remote_retrieve_body( $release_response ), true );
 
-		if ( ! is_array( $release_data ) || empty( $release_data[0] ) ) {
+		if ( ! is_array( $release_data ) || empty( $release_data['tag_name'] ) ) {
 			continue;
 		}
 
-		$release = $release_data[0];
+		$release = $release_data;
 
 		if ( empty( $release['tag_name'] ) || empty( $release['published_at'] ) || empty( $release['html_url'] ) ) {
 			continue;

--- a/inc/home/templates/section-3x3-grid.php
+++ b/inc/home/templates/section-3x3-grid.php
@@ -93,7 +93,7 @@ $events_url      = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'even
 		</div>
 		<div class="home-3x3-stacked-section">
 			<div class="home-3x3-header">
-				<span class="home-3x3-label"><?php esc_html_e( 'Shows Near You', 'extrachill-blog' ); ?></span>
+				<span class="home-3x3-label"><?php esc_html_e( 'Top Event Markets', 'extrachill-blog' ); ?></span>
 				<a class="home-3x3-archive-link button-3 button-small" href="<?php echo esc_url( $events_url ); ?>"><?php esc_html_e( 'View All', 'extrachill-blog' ); ?></a>
 			</div>
 			<?php if ( ! empty( $location_counts ) ) : ?>

--- a/inc/home/templates/section-events.php
+++ b/inc/home/templates/section-events.php
@@ -2,7 +2,7 @@
 /**
  * Homepage Events Card
  *
- * City badges with live counts render in the top grid ("Shows Near You"),
+ * City badges with live counts render in the top grid ("Top Event Markets"),
  * so this card focuses on the mission + submission CTA.
  *
  * @package ExtraChillBlog

--- a/inc/home/templates/section-recently-shipped.php
+++ b/inc/home/templates/section-recently-shipped.php
@@ -1,12 +1,9 @@
 <?php
 /**
- * Homepage Recently Shipped Strip
+ * Homepage Recently Shipped Card
  *
- * Surfaces recent GitHub releases across the whole Extra-Chill org — the
- * platform plugins alongside the agent tooling (homeboy, data-machine)
- * that builds and ships them. Renders nothing when the payload is
- * empty/unavailable; this section must degrade to invisible, never to
- * an error or empty-state box.
+ * Surfaces recent GitHub releases across the whole Extra-Chill org. Renders
+ * nothing when the scheduled payload is empty or unavailable.
  *
  * @package ExtraChillBlog
  * @since 0.1.0
@@ -22,54 +19,50 @@ $releases                = $recently_shipped['releases'];
 $repos_active_this_month = $recently_shipped['repos_active_this_month'];
 $repos_total             = $recently_shipped['repos_total'];
 ?>
-<div class="full-width-breakout ec-edge-shell">
-	<div class="home-shipped-strip">
-		<div class="home-shipped-header">
-			<span class="home-shipped-label"><?php esc_html_e( 'Recently Shipped', 'extrachill-blog' ); ?></span>
-			<span class="home-shipped-kicker"><?php esc_html_e( 'recent releases from active repositories', 'extrachill-blog' ); ?></span>
-		</div>
-		<div class="home-shipped-list">
-			<?php foreach ( $releases as $release ) : ?>
-				<a
-					href="<?php echo esc_url( $release['url'] ); ?>"
-					class="home-shipped-row"
-					target="_blank"
-					rel="noopener"
-					aria-label="<?php echo esc_attr( sprintf( '%s %s', $release['repo'], $release['tag'] ) ); ?>"
-				>
-					<span class="home-shipped-type home-shipped-type-<?php echo esc_attr( $release['type'] ); ?>"><?php echo esc_html( $release['type'] ); ?></span>
-					<span class="home-shipped-main">
-						<span class="home-shipped-repo"><?php echo esc_html( $release['repo'] ); ?></span>
-						<span class="home-shipped-tag"><?php echo esc_html( $release['tag'] ); ?></span>
-						<?php if ( ! empty( $release['summary'] ) ) : ?>
-							<span class="home-shipped-summary"><?php echo esc_html( $release['summary'] ); ?></span>
-						<?php endif; ?>
-					</span>
-					<span class="home-shipped-meta">
-						<?php
-						printf(
-							/* translators: %s: human-readable time difference, e.g. "3 hours" */
-							esc_html__( '%s ago', 'extrachill-blog' ),
-							esc_html( human_time_diff( $release['published_at'], time() ) )
-						);
-						?>
-					</span>
-				</a>
-			<?php endforeach; ?>
-		</div>
-		<?php if ( $repos_total > 0 ) : ?>
-			<div class="home-shipped-footer">
-				<?php
-				printf(
-					/* translators: 1: number of repos active this month, 2: total repo count */
-					esc_html__( '%1$d of %2$d repos active this month', 'extrachill-blog' ),
-					absint( $repos_active_this_month ),
-					absint( $repos_total )
-				);
-				?>
-				&middot;
-				<a href="https://github.com/Extra-Chill" target="_blank" rel="noopener"><?php esc_html_e( 'See it all on GitHub', 'extrachill-blog' ); ?></a>
-			</div>
-		<?php endif; ?>
+<div class="home-network-card home-shipped-card" aria-labelledby="recently-shipped-header">
+	<h2 class="home-network-card-header" id="recently-shipped-header"><?php esc_html_e( 'Recently Shipped', 'extrachill-blog' ); ?></h2>
+	<p class="home-network-card-description home-shipped-kicker"><?php esc_html_e( 'Recent releases from our public GitHub organization.', 'extrachill-blog' ); ?></p>
+	<div class="home-shipped-list">
+		<?php foreach ( $releases as $release ) : ?>
+			<a
+				href="<?php echo esc_url( $release['url'] ); ?>"
+				class="home-shipped-row"
+				target="_blank"
+				rel="noopener"
+				aria-label="<?php echo esc_attr( sprintf( '%s %s', $release['repo'], $release['tag'] ) ); ?>"
+			>
+				<span class="home-shipped-type home-shipped-type-<?php echo esc_attr( $release['type'] ); ?>"><?php echo esc_html( $release['type'] ); ?></span>
+				<span class="home-shipped-main">
+					<span class="home-shipped-repo"><?php echo esc_html( $release['repo'] ); ?></span>
+					<span class="home-shipped-tag"><?php echo esc_html( $release['tag'] ); ?></span>
+					<?php if ( ! empty( $release['summary'] ) ) : ?>
+						<span class="home-shipped-summary"><?php echo esc_html( $release['summary'] ); ?></span>
+					<?php endif; ?>
+				</span>
+				<span class="home-shipped-meta">
+					<?php
+					printf(
+						/* translators: %s: human-readable time difference, e.g. "3 hours" */
+						esc_html__( '%s ago', 'extrachill-blog' ),
+						esc_html( human_time_diff( $release['published_at'], time() ) )
+					);
+					?>
+				</span>
+			</a>
+		<?php endforeach; ?>
 	</div>
+	<?php if ( $repos_total > 0 ) : ?>
+		<div class="home-shipped-footer">
+			<?php
+			printf(
+				/* translators: 1: number of repos active this month, 2: total repo count */
+				esc_html__( '%1$d of %2$d repos active this month', 'extrachill-blog' ),
+				absint( $repos_active_this_month ),
+				absint( $repos_total )
+			);
+			?>
+			&middot;
+			<a href="https://github.com/Extra-Chill" target="_blank" rel="noopener"><?php esc_html_e( 'See it all on GitHub', 'extrachill-blog' ); ?></a>
+		</div>
+	<?php endif; ?>
 </div>


### PR DESCRIPTION
## Summary
- make Recently Shipped the sixth network card, restoring the intended 3x2 desktop grid instead of interrupting navigation with a full-width strip
- preserve release rows, type badges, summaries, timestamps, monthly activity, accessible labeling, and the GitHub link in card-scale responsive markup
- rename the inventory-ranked event module to the truthful `Top Event Markets` label

## Layout
The network grid now explicitly uses three equal columns at its desktop breakpoint, producing two rows of three cards. At 900px and below it retains the established single-column mobile layout, while release rows wrap within the card to prevent overflow.

## Persistence and request behavior
The live regression occurred because `extrachill_blog_recently_shipped_last_good` was stored only as a transient, which could disappear during persistent object-cache or deploy churn while stale anonymous full-page HTML still showed it. The hourly warmer now stores successful payloads in a durable, non-autoloaded WordPress option. Existing transient data is migrated on read, and failed refreshes return without replacing the last-good option.

Frontend rendering only reads the durable option (or performs the one-time legacy transient migration). All GitHub HTTP calls remain confined to the scheduled hourly refresh callback; no synchronous GitHub request was added to a frontend request path.

## GitHub release behavior
Release discovery now uses GitHub's `/releases/latest` endpoint and parses its object response, so draft or otherwise unpublished releases do not hide a repository's latest published stable release.

## Tests
- `php -l` on every changed PHP file
- changed-file WordPress PHPCS: pass
- structural checks: six templates inside `.home-network-grid`; explicit 3-column desktop and 1-column mobile rules; HTTP calls confined to the scheduled fetch function
- `composer test`: repository-wide PHPCS remains blocked by pre-existing violations in unrelated files including `inc/single/login-register-cta.php`, `inc/core/co-authors.php`, `inc/core/ads-filter.php`, and `inc/core/admin-customizations.php`

Closes #37