### PR TITLE
feat: compose festival archive pillars

### DIFF
--- a/assets/css/festival-pillar.css
+++ b/assets/css/festival-pillar.css
@@ -1,0 +1,86 @@
+.festival-pillar-routes {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+	gap: var(--spacing-md);
+	margin: var(--spacing-lg) 0 var(--spacing-xl);
+}
+
+.festival-pillar-route {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-xs);
+	padding: var(--spacing-lg);
+	color: var(--text-color);
+	text-decoration: none;
+	background: var(--card-background);
+	border: 1px solid var(--border-color);
+	border-left: 5px solid var(--accent);
+	border-radius: var(--border-radius-lg);
+	box-shadow: var(--card-shadow);
+	transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.festival-pillar-route:hover,
+.festival-pillar-route:focus-visible {
+	color: var(--text-color);
+	transform: translateY(-2px);
+	box-shadow: var(--card-hover-shadow);
+}
+
+.festival-pillar-route-events {
+	border-left-color: var(--link-color);
+}
+
+.festival-pillar-route-kicker,
+.festival-pillar-coverage-header p {
+	margin: 0;
+	color: var(--muted-text);
+	font-size: var(--font-size-sm);
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+}
+
+.festival-pillar-route strong {
+	font-family: var(--font-family-heading);
+	font-size: var(--font-size-xl);
+	line-height: var(--line-height-tight);
+}
+
+.festival-pillar-route > span:last-child {
+	color: var(--muted-text);
+}
+
+.festival-pillar-coverage-header {
+	margin: var(--spacing-xl) 0 var(--spacing-lg);
+}
+
+.festival-pillar-coverage-header h2 {
+	margin: var(--spacing-xs) 0 0;
+}
+
+.festival-pillar-newsletter {
+	max-width: var(--content-width);
+	margin: var(--spacing-xl) auto;
+	padding: var(--spacing-xl);
+	text-align: center;
+	background: var(--card-background);
+	border-top: 4px solid var(--accent);
+	border-radius: var(--border-radius-lg);
+	box-shadow: var(--card-shadow);
+}
+
+.festival-pillar-newsletter h2 {
+	margin-top: 0;
+}
+
+@media (max-width: 600px) {
+	.festival-pillar-routes {
+		grid-template-columns: 1fr;
+	}
+
+	.festival-pillar-route,
+	.festival-pillar-newsletter {
+		padding: var(--spacing-md);
+	}
+}

--- a/extrachill-blog.php
+++ b/extrachill-blog.php
@@ -34,6 +34,7 @@ require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/home/homepage-hooks.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/power/power-page.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/blog-archive-routing.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/breadcrumbs.php';
+require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/festival-pillar.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/share-card.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/network-bridge.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/login-register-cta.php';
@@ -50,6 +51,16 @@ function extrachill_blog_register_styles() {
 		EXTRACHILL_BLOG_PLUGIN_URL . 'assets/css/share-card.css',
 		array(),
 		$version
+	);
+
+	$festival_version = filemtime( EXTRACHILL_BLOG_PLUGIN_DIR . 'assets/css/festival-pillar.css' );
+	$festival_version = false === $festival_version ? null : (string) $festival_version;
+
+	wp_register_style(
+		'extrachill-blog-festival-pillar',
+		EXTRACHILL_BLOG_PLUGIN_URL . 'assets/css/festival-pillar.css',
+		array( 'extrachill-root' ),
+		$festival_version
 	);
 }
 add_action( 'wp_enqueue_scripts', 'extrachill_blog_register_styles', 5 );

--- a/inc/archive/festival-pillar.php
+++ b/inc/archive/festival-pillar.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Main-site festival pillar composition.
+ *
+ * @package ExtraChillBlog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Check whether the current request is a main-site festival archive.
+ *
+ * @return bool
+ */
+function extrachill_blog_is_festival_pillar() {
+	$is_main_site = function_exists( 'ec_get_current_site_key' )
+		? 'main' === ec_get_current_site_key()
+		: 1 === (int) get_current_blog_id();
+
+	return $is_main_site && is_tax( 'festival' );
+}
+
+/**
+ * Replace generic taxonomy buttons with the festival pillar navigation.
+ *
+ * @return void
+ */
+function extrachill_blog_prepare_festival_pillar() {
+	if ( ! extrachill_blog_is_festival_pillar() ) {
+		return;
+	}
+
+	remove_action( 'extrachill_archive_below_description', 'extrachill_render_cross_site_taxonomy_links' );
+	wp_enqueue_style( 'extrachill-blog-festival-pillar' );
+}
+add_action( 'wp', 'extrachill_blog_prepare_festival_pillar' );
+
+/**
+ * Render the festival's specialized network destinations.
+ *
+ * @return void
+ */
+function extrachill_blog_render_festival_network_routes() {
+	if ( ! extrachill_blog_is_festival_pillar() || ! function_exists( 'extrachill_get_cross_site_term_links' ) ) {
+		return;
+	}
+
+	$term = get_queried_object();
+	if ( ! ( $term instanceof WP_Term ) ) {
+		return;
+	}
+
+	$network_links = extrachill_get_cross_site_term_links( $term, 'festival' );
+	$links         = array();
+	foreach ( $network_links as $link ) {
+		if ( ! empty( $link['site_key'] ) ) {
+			$links[ $link['site_key'] ] = $link;
+		}
+	}
+
+	if ( empty( $links['wire'] ) && empty( $links['events'] ) ) {
+		return;
+	}
+
+	/* translators: %s: festival name. */
+	$navigation_label = sprintf( __( '%s across Extra Chill', 'extrachill-blog' ), $term->name );
+	/* translators: %s: festival name. */
+	$wire_title = sprintf( __( 'Latest %s updates', 'extrachill-blog' ), $term->name );
+	/* translators: %s: number of Festival Wire stories. */
+	$wire_count = ! empty( $links['wire'] ) ? sprintf( _n( '%s report, rumor, and announcement', '%s reports, rumors, and announcements', (int) $links['wire']['count'], 'extrachill-blog' ), number_format_i18n( (int) $links['wire']['count'] ) ) : '';
+	/* translators: %s: festival name. */
+	$events_title = sprintf( __( 'Upcoming %s dates', 'extrachill-blog' ), $term->name );
+	/* translators: %s: number of upcoming events. */
+	$events_count = ! empty( $links['events'] ) ? sprintf( _n( '%s upcoming event', '%s upcoming events', (int) $links['events']['count'], 'extrachill-blog' ), number_format_i18n( (int) $links['events']['count'] ) ) : '';
+	?>
+	<nav class="festival-pillar-routes" aria-label="<?php echo esc_attr( $navigation_label ); ?>">
+		<?php if ( ! empty( $links['wire'] ) ) : ?>
+			<a class="festival-pillar-route festival-pillar-route-wire" href="<?php echo esc_url( $links['wire']['url'] ); ?>">
+				<span class="festival-pillar-route-kicker"><?php esc_html_e( 'Festival Wire', 'extrachill-blog' ); ?></span>
+				<strong><?php echo esc_html( $wire_title ); ?></strong>
+				<span><?php echo esc_html( $wire_count ); ?></span>
+			</a>
+		<?php endif; ?>
+
+		<?php if ( ! empty( $links['events'] ) ) : ?>
+			<a class="festival-pillar-route festival-pillar-route-events" href="<?php echo esc_url( $links['events']['url'] ); ?>">
+				<span class="festival-pillar-route-kicker"><?php esc_html_e( 'Events', 'extrachill-blog' ); ?></span>
+				<strong><?php echo esc_html( $events_title ); ?></strong>
+				<span><?php echo esc_html( $events_count ); ?></span>
+			</a>
+		<?php endif; ?>
+	</nav>
+	<?php
+}
+add_action( 'extrachill_archive_below_description', 'extrachill_blog_render_festival_network_routes' );
+
+/**
+ * Frame the main archive loop as the festival's editorial coverage.
+ *
+ * @return void
+ */
+function extrachill_blog_render_festival_coverage_heading() {
+	if ( ! extrachill_blog_is_festival_pillar() ) {
+		return;
+	}
+
+	$term = get_queried_object();
+	if ( ! ( $term instanceof WP_Term ) ) {
+		return;
+	}
+
+	printf(
+		'<header class="festival-pillar-coverage-header"><p>%s</p><h2>%s</h2></header>',
+		esc_html__( 'From the publication', 'extrachill-blog' ),
+		/* translators: %s: festival name. */
+		esc_html( sprintf( __( 'Extra Chill coverage of %s', 'extrachill-blog' ), $term->name ) )
+	);
+}
+add_action( 'extrachill_archive_above_posts', 'extrachill_blog_render_festival_coverage_heading', 20 );
+
+/**
+ * Render the existing network newsletter form after the archive content.
+ *
+ * @return void
+ */
+function extrachill_blog_render_festival_newsletter() {
+	if ( ! extrachill_blog_is_festival_pillar() || is_paged() ) {
+		return;
+	}
+	?>
+	<section class="festival-pillar-newsletter" aria-labelledby="festival-pillar-newsletter-title">
+		<h2 id="festival-pillar-newsletter-title"><?php esc_html_e( 'Stay in the festival loop', 'extrachill-blog' ); ?></h2>
+		<p><?php esc_html_e( 'Get music news, festival updates, and the best of Extra Chill delivered to your inbox.', 'extrachill-blog' ); ?></p>
+		<?php do_action( 'extrachill_render_newsletter_form', 'archive' ); ?>
+	</section>
+	<?php
+}
+add_action( 'extrachill_after_body_content', 'extrachill_blog_render_festival_newsletter', 8 );


### PR DESCRIPTION
## Summary

- turn main-site festival taxonomy archives into editorial network pillars without replacing WordPress routing or the native post loop
- promote existing Wire and upcoming Events destinations into distinct, count-aware route cards
- frame the main archive as Extra Chill editorial coverage and reuse the existing newsletter form for a truthful general festival/news CTA
- conditionally load responsive pillar styles only on main-site festival archives

Fixes #41.

## Architecture

This consumes existing primitives rather than introducing a generic hub framework:

- WordPress taxonomy archive and query own editorial coverage
- Extra Chill Network resolves equivalent festival archives by slug
- Events owns upcoming-event semantics
- Wire owns the chronological update feed
- Newsletter keeps its existing archive subscription context

Main, Wire, and Events remain self-canonical because each page serves distinct intent. Taxonomy notifications and Community festival tagging are intentionally separate owner-level follow-ups.

## Verification

- `php -l extrachill-blog.php`
- `php -l inc/archive/festival-pillar.php`
- `git diff --check`
- changed-file PHPCS passes with no findings

Local PHPStan remains unavailable because the installed PHAR has an oversized manifest. The local WP Codebox test runner is also missing its recipe-builder export; CI remains the authoritative integration gate.