### PR TITLE
feat: add festival subscription updates

### DIFF
--- a/assets/css/festival-pillar.css
+++ b/assets/css/festival-pillar.css
@@ -63,6 +63,56 @@
 	margin: var(--spacing-xs) 0 0;
 }
 
+.festival-pillar-subscription {
+	margin: var(--spacing-lg) 0;
+	padding: var(--spacing-lg);
+	background: var(--card-background);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-lg);
+}
+
+.festival-pillar-subscription h2,
+.festival-pillar-subscription p {
+	margin-top: 0;
+}
+
+.festival-pillar-subscription-button {
+	display: inline-block;
+	padding: 0.7rem 1rem;
+	color: var(--background-color);
+	font: inherit;
+	font-weight: 700;
+	text-decoration: none;
+	cursor: pointer;
+	background: var(--accent);
+	border: 1px solid var(--accent);
+	border-radius: var(--border-radius);
+}
+
+.festival-pillar-subscription-button:hover,
+.festival-pillar-subscription-button:focus-visible {
+	color: var(--background-color);
+	background: var(--accent-hover);
+	border-color: var(--accent-hover);
+}
+
+.festival-pillar-subscription-button[aria-pressed="true"] {
+	color: var(--text-color);
+	background: transparent;
+	border-color: var(--text-color);
+}
+
+.festival-pillar-subscription-button:disabled {
+	cursor: wait;
+	opacity: 0.65;
+}
+
+.festival-pillar-subscription-status {
+	min-height: 1.5em;
+	margin-bottom: 0;
+	color: var(--muted-text);
+}
+
 .festival-pillar-newsletter {
 	max-width: var(--content-width);
 	margin: var(--spacing-xl) auto;
@@ -84,7 +134,8 @@
 	}
 
 	.festival-pillar-route,
-	.festival-pillar-newsletter {
+	.festival-pillar-newsletter,
+	.festival-pillar-subscription {
 		padding: var(--spacing-md);
 	}
 }

--- a/assets/js/festival-subscriptions.js
+++ b/assets/js/festival-subscriptions.js
@@ -1,0 +1,63 @@
+( function () {
+	'use strict';
+
+	const buttons = document.querySelectorAll( '.festival-pillar-subscription-button[data-endpoint]' );
+
+	function setState( button, subscribed, message ) {
+		button.setAttribute( 'aria-pressed', subscribed ? 'true' : 'false' );
+		button.textContent = subscribed ? 'Subscribed to updates' : 'Subscribe to updates';
+		button.closest( '.festival-pillar-subscription' ).querySelector( '.festival-pillar-subscription-status' ).textContent = message || '';
+	}
+
+	function request( button, ability, method ) {
+		const input = {
+			entity_type: button.dataset.entityType,
+			taxonomy: button.dataset.taxonomy,
+			slug: button.dataset.slug,
+		};
+		let url = button.dataset.endpoint + 'extrachill/' + ability + '/run';
+		const options = {
+			method: method,
+			credentials: 'same-origin',
+			headers: { 'X-WP-Nonce': button.dataset.nonce },
+		};
+
+		if ( 'GET' === method ) {
+			url += '?input=' + encodeURIComponent( JSON.stringify( input ) );
+		} else {
+			options.headers['Content-Type'] = 'application/json';
+			options.body = JSON.stringify( { input: input } );
+		}
+
+		return window.fetch( url, options ).then( function ( response ) {
+			return response.json().then( function ( data ) {
+				if ( ! response.ok ) {
+					throw new Error( data.message || 'Unable to update this subscription.' );
+				}
+				return data;
+			} );
+		} );
+	}
+
+	buttons.forEach( function ( button ) {
+		request( button, 'entity-subscription-status', 'GET' ).then( function ( data ) {
+			setState( button, Boolean( data.subscribed ) );
+		} ).catch( function () {
+			button.closest( '.festival-pillar-subscription' ).querySelector( '.festival-pillar-subscription-status' ).textContent = 'Subscription status is unavailable. Please try again.';
+		} ).finally( function () {
+			button.disabled = false;
+		} );
+
+		button.addEventListener( 'click', function () {
+			const subscribed = 'true' === button.getAttribute( 'aria-pressed' );
+			button.disabled = true;
+			request( button, subscribed ? 'entity-unsubscribe' : 'entity-subscribe', 'POST' ).then( function ( data ) {
+				setState( button, Boolean( data.subscribed ), data.subscribed ? 'You will receive festival updates.' : 'You will no longer receive festival updates.' );
+			} ).catch( function () {
+				button.closest( '.festival-pillar-subscription' ).querySelector( '.festival-pillar-subscription-status' ).textContent = 'Unable to update your subscription. Please try again.';
+			} ).finally( function () {
+				button.disabled = false;
+			} );
+		} );
+	} );
+}() );

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "lint:fix": "vendor/bin/phpcbf --standard=WordPress *.php inc/",
         "test": [
             "php tests/homepage-event-markets.php",
+            "php tests/festival-subscriptions.php",
             "@lint:php"
         ]
     },

--- a/extrachill-blog.php
+++ b/extrachill-blog.php
@@ -35,6 +35,7 @@ require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/power/power-page.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/blog-archive-routing.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/breadcrumbs.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/festival-pillar.php';
+require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/festival-subscriptions.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/share-card.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/network-bridge.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/login-register-cta.php';
@@ -61,6 +62,17 @@ function extrachill_blog_register_styles() {
 		EXTRACHILL_BLOG_PLUGIN_URL . 'assets/css/festival-pillar.css',
 		array( 'extrachill-root' ),
 		$festival_version
+	);
+
+	$festival_script_version = filemtime( EXTRACHILL_BLOG_PLUGIN_DIR . 'assets/js/festival-subscriptions.js' );
+	$festival_script_version = false === $festival_script_version ? null : (string) $festival_script_version;
+
+	wp_register_script(
+		'extrachill-blog-festival-subscriptions',
+		EXTRACHILL_BLOG_PLUGIN_URL . 'assets/js/festival-subscriptions.js',
+		array(),
+		$festival_script_version,
+		true
 	);
 }
 add_action( 'wp_enqueue_scripts', 'extrachill_blog_register_styles', 5 );

--- a/inc/archive/festival-subscriptions.php
+++ b/inc/archive/festival-subscriptions.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Festival pillar subscription controls and publication notifications.
+ *
+ * @package ExtraChillBlog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_PRODUCER      = 'extrachill-blog';
+const EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_NOTIFIED_META = '_extrachill_blog_festival_subscriptions_notified';
+
+/**
+ * Allow this plugin to resolve private festival subscription recipients.
+ *
+ * @param bool   $authorized Whether the producer is already authorized.
+ * @param string $producer   Producer requesting recipients.
+ * @return bool
+ */
+function extrachill_blog_authorize_festival_subscription_producer( $authorized, $producer ) {
+	return $authorized || EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_PRODUCER === $producer;
+}
+add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrachill_blog_authorize_festival_subscription_producer', 10, 2 );
+
+/**
+ * Render the private festival notification subscription control.
+ *
+ * @return void
+ */
+function extrachill_blog_render_festival_subscription_control() {
+	if ( ! extrachill_blog_is_festival_pillar() || is_paged() ) {
+		return;
+	}
+
+	$term = get_queried_object();
+	if ( ! ( $term instanceof WP_Term ) ) {
+		return;
+	}
+
+	if ( ! is_user_logged_in() ) {
+		?>
+		<section class="festival-pillar-subscription" aria-labelledby="festival-pillar-subscription-title">
+			<h2 id="festival-pillar-subscription-title"><?php esc_html_e( 'Get festival updates', 'extrachill-blog' ); ?></h2>
+			<p><?php esc_html_e( 'Log in to subscribe to private Extra Chill notifications for this festival.', 'extrachill-blog' ); ?></p>
+			<a class="festival-pillar-subscription-button" href="<?php echo esc_url( wp_login_url( get_term_link( $term ) ) ); ?>"><?php esc_html_e( 'Log in to subscribe', 'extrachill-blog' ); ?></a>
+		</section>
+		<?php
+		return;
+	}
+
+	wp_enqueue_script( 'extrachill-blog-festival-subscriptions' );
+	?>
+	<section class="festival-pillar-subscription" aria-labelledby="festival-pillar-subscription-title">
+		<h2 id="festival-pillar-subscription-title"><?php esc_html_e( 'Get festival updates', 'extrachill-blog' ); ?></h2>
+		<p><?php esc_html_e( 'Subscribe to private Extra Chill notifications for new editorial coverage of this festival.', 'extrachill-blog' ); ?></p>
+		<button
+			class="festival-pillar-subscription-button"
+			type="button"
+			aria-pressed="false"
+			disabled
+			data-entity-type="festival"
+			data-taxonomy="festival"
+			data-slug="<?php echo esc_attr( $term->slug ); ?>"
+			data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>"
+			data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>"
+		>
+			<?php esc_html_e( 'Subscribe to updates', 'extrachill-blog' ); ?>
+		</button>
+		<p class="festival-pillar-subscription-status" aria-live="polite"></p>
+	</section>
+	<?php
+}
+add_action( 'extrachill_archive_below_description', 'extrachill_blog_render_festival_subscription_control', 5 );
+
+/**
+ * Get canonical festival terms assigned to a main editorial post.
+ *
+ * @param int $post_id Post ID.
+ * @return WP_Term[] Festival terms.
+ */
+function extrachill_blog_get_post_festival_terms( $post_id ) {
+	$terms = wp_get_post_terms( $post_id, 'festival' );
+
+	return is_wp_error( $terms ) ? array() : $terms;
+}
+
+/**
+ * Notify unique festival subscribers only when a main post first publishes.
+ *
+ * @param string  $new_status New post status.
+ * @param string  $old_status Previous post status.
+ * @param WP_Post $post       Published post.
+ * @return void
+ */
+function extrachill_blog_notify_festival_subscribers( $new_status, $old_status, $post ) {
+	if ( 'publish' !== $new_status || 'publish' === $old_status || ! is_object( $post ) || 'post' !== $post->post_type ) {
+		return;
+	}
+	$is_main_site = function_exists( 'ec_get_current_site_key' )
+		? 'main' === ec_get_current_site_key()
+		: 1 === (int) get_current_blog_id();
+	if ( ! $is_main_site ) {
+		return;
+	}
+
+	if ( get_post_meta( $post->ID, EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_NOTIFIED_META, true ) ) {
+		return;
+	}
+
+	$terms = extrachill_blog_get_post_festival_terms( $post->ID );
+	if ( empty( $terms ) || ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify' ) ) {
+		return;
+	}
+
+	$recipient_ids = array();
+	foreach ( $terms as $term ) {
+		if ( ! ( $term instanceof WP_Term ) ) {
+			continue;
+		}
+
+		$recipients = extrachill_users_entity_subscription_recipients(
+			EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_PRODUCER,
+			'festival',
+			'festival',
+			$term->slug
+		);
+		if ( ! is_wp_error( $recipients ) ) {
+			$recipient_ids = array_merge( $recipient_ids, $recipients );
+		}
+	}
+
+	$recipient_ids = array_values( array_unique( array_map( 'absint', $recipient_ids ) ) );
+	$recipient_ids = array_filter( $recipient_ids );
+	if ( empty( $recipient_ids ) ) {
+		update_post_meta( $post->ID, EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_NOTIFIED_META, current_time( 'mysql', true ) );
+		return;
+	}
+
+	$actor_id = (int) $post->post_author;
+	if ( ! get_userdata( $actor_id ) && function_exists( 'ec_get_network_bot_user_id' ) ) {
+		$actor_id = ec_get_network_bot_user_id();
+	}
+	if ( $actor_id <= 0 || ! get_userdata( $actor_id ) ) {
+		return;
+	}
+
+	ec_users_notify(
+		$recipient_ids,
+		array(
+			'actor_id' => $actor_id,
+			'type'     => 'festival_update',
+			/* translators: %s: post title. */
+			'title'    => sprintf( __( 'New festival update: %s', 'extrachill-blog' ), get_the_title( $post ) ),
+			'link'     => get_permalink( $post ),
+			'item_id'  => (int) $post->ID,
+		)
+	);
+
+	// Guard re-publishes and later edits after the initial notification attempt.
+	update_post_meta( $post->ID, EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_NOTIFIED_META, current_time( 'mysql', true ) );
+}
+add_action( 'transition_post_status', 'extrachill_blog_notify_festival_subscribers', 10, 3 );

--- a/tests/festival-subscriptions.php
+++ b/tests/festival-subscriptions.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Focused smoke coverage for festival subscription notifications.
+ *
+ * Run with: php tests/festival-subscriptions.php
+ */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+class WP_Term {
+	public $slug;
+
+	public function __construct( $slug ) {
+		$this->slug = $slug;
+	}
+}
+
+$test_meta          = array();
+$test_notifications = array();
+
+function add_action() {}
+function add_filter() {}
+function is_wp_error() {
+	return false;
+}
+function wp_get_post_terms() {
+	return array( new WP_Term( 'festival-one' ), new WP_Term( 'festival-two' ) );
+}
+function get_post_meta( $post_id, $key ) {
+	global $test_meta;
+	return $test_meta[ $post_id ][ $key ] ?? '';
+}
+function update_post_meta( $post_id, $key, $value ) {
+	global $test_meta;
+	$test_meta[ $post_id ][ $key ] = $value;
+}
+function current_time() {
+	return '2026-07-12 20:00:00';
+}
+function get_current_blog_id() {
+	return 1;
+}
+function get_userdata( $user_id ) {
+	return $user_id > 0 ? (object) array( 'ID' => $user_id ) : false;
+}
+function absint( $value ) {
+	return abs( (int) $value );
+}
+function get_the_title() {
+	return 'Festival coverage';
+}
+function get_permalink() {
+	return 'https://extrachill.com/festival-coverage/';
+}
+function __( $text ) {
+	return $text;
+}
+function extrachill_users_entity_subscription_recipients( $producer, $entity_type, $taxonomy, $slug ) {
+	if ( 'extrachill-blog' !== $producer || 'festival' !== $entity_type || 'festival' !== $taxonomy ) {
+		return array();
+	}
+	return 'festival-one' === $slug ? array( 4, 7 ) : array( 7, 9 );
+}
+function ec_users_notify( $recipient_ids, $data ) {
+	global $test_notifications;
+	$test_notifications[] = array(
+		'recipient_ids' => $recipient_ids,
+		'data'          => $data,
+	);
+}
+
+require_once dirname( __DIR__ ) . '/inc/archive/festival-subscriptions.php';
+
+function assert_same( $expected, $actual, $message ) {
+	if ( $expected !== $actual ) {
+		fwrite( STDERR, $message . "\n" );
+		exit( 1 );
+	}
+}
+
+assert_same( true, extrachill_blog_authorize_festival_subscription_producer( false, 'extrachill-blog' ), 'Blog producer must be authorized.' );
+assert_same( false, extrachill_blog_authorize_festival_subscription_producer( false, 'untrusted-producer' ), 'Untrusted producer must remain unauthorized.' );
+
+$post = (object) array(
+	'ID'          => 46,
+	'post_type'   => 'post',
+	'post_author' => 12,
+);
+
+extrachill_blog_notify_festival_subscribers( 'publish', 'draft', $post );
+assert_same( 1, count( $test_notifications ), 'First publication should notify subscribers once.' );
+assert_same( array( 4, 7, 9 ), $test_notifications[0]['recipient_ids'], 'Recipients from multiple festival terms must be unique.' );
+assert_same( 'festival_update', $test_notifications[0]['data']['type'], 'Festival updates must use their dedicated notification type.' );
+
+extrachill_blog_notify_festival_subscribers( 'publish', 'draft', $post );
+assert_same( 1, count( $test_notifications ), 'Publish guard must prevent duplicate notifications.' );
+
+fwrite( STDOUT, "Festival subscription tests passed.\n" );


### PR DESCRIPTION
## Summary
- Add an accessible main festival-pillar subscription control backed by the Users-owned entity subscription abilities.
- Authorize the stable `extrachill-blog` producer and notify only private festival subscribers when a main editorial post first publishes.
- Add native smoke coverage for producer authorization, recipient de-duplication, and the once-only publish guard.

## Security and Privacy
- The UI sends the canonical festival identity only to `extrachill/entity-subscription-status`, `extrachill/entity-subscribe`, and `extrachill/entity-unsubscribe` through the WordPress Abilities REST endpoint with the existing `wp_rest` nonce convention.
- Anonymous readers receive a login URL with the pillar as the return target. The recipient resolution remains a private PHP call authorized by the Users filter; no counts, recipient IDs, or audience details are rendered or logged.
- Notification delivery checks the post is a main-site `post`, uses its valid author (falling back to the configured network bot only when needed), and records a per-post guard after the first delivery attempt.

## UI States
- Logged-out readers see a login-to-subscribe link.
- Logged-in readers see a disabled control while private status loads, then an `aria-pressed` subscribe/unsubscribe state with polite success and failure announcements.
- The existing newsletter form is unchanged and remains separate from notification subscriptions.

## Producer Behavior
- `extrachill-blog` is authorized as a stable producer through `extrachill_users_entity_subscription_producer_authorized`.
- On a first transition into publish, all assigned festival terms are resolved privately, recipient IDs are de-duplicated across terms, and one `festival_update` notification is created per unique subscriber. Later updates and re-publishes are suppressed by the post-meta guard.

## Verification
- `php tests/festival-subscriptions.php`
- `php tests/homepage-event-markets.php`
- `vendor/bin/phpcs --standard=WordPress extrachill-blog.php inc/archive/festival-subscriptions.php`
- `php -l inc/archive/festival-subscriptions.php`
- `php -l tests/festival-subscriptions.php`
- `php -l extrachill-blog.php`
- `node --check assets/js/festival-subscriptions.js`
- `composer test` runs both smoke tests but still exits non-zero on pre-existing PHPCS violations in unrelated `inc/core/co-authors.php`, `inc/core/ads-filter.php`, `inc/core/admin-customizations.php`, and `inc/single/login-register-cta.php`.