### PR TITLE
refactor: consume canonical Local Scene

### DIFF
--- a/inc/home/homepage-queries.php
+++ b/inc/home/homepage-queries.php
@@ -41,7 +41,7 @@ function extrachill_blog_get_location_event_counts() {
 		return array();
 	}
 
-	$preferred_slug = extrachill_blog_get_default_event_location_slug();
+	$preferred_slug = extrachill_blog_get_local_scene_slug();
 	if ( '' === $preferred_slug ) {
 		return $locations;
 	}
@@ -87,7 +87,7 @@ function extrachill_blog_request_location_event_counts( $query ) {
 }
 
 /**
- * Read the authenticated user's canonical default event location.
+ * Read the authenticated user's canonical local scene.
  *
  * The preference is supplied by extrachill-users#179 through the existing
  * self-only settings Ability. Its resolved object is canonicalized by the
@@ -97,7 +97,7 @@ function extrachill_blog_request_location_event_counts( $query ) {
  *
  * @return string Canonical location slug, or an empty string.
  */
-function extrachill_blog_get_default_event_location_slug() {
+function extrachill_blog_get_local_scene_slug() {
 	if (
 		! is_user_logged_in() ||
 		! function_exists( 'wp_has_ability' ) ||
@@ -117,7 +117,7 @@ function extrachill_blog_get_default_event_location_slug() {
 		return '';
 	}
 
-	$location = $settings['default_event_location'] ?? null;
+	$location = $settings['local_scene'] ?? null;
 	if ( ! is_array( $location ) || empty( $location['slug'] ) ) {
 		return '';
 	}

--- a/tests/homepage-event-markets.php
+++ b/tests/homepage-event-markets.php
@@ -79,17 +79,24 @@ assert_same( 'market-7', $result[7]['slug'], 'Global order should be retained af
 $result = extrachill_blog_prioritize_event_market( $global, array() );
 assert_same( $global, $result, 'Missing preference should retain global markets unchanged.' );
 
-assert_same( '', extrachill_blog_get_default_event_location_slug(), 'Anonymous requests should not read a preference.' );
+assert_same( '', extrachill_blog_get_local_scene_slug(), 'Anonymous requests should not read a preference.' );
 
 $test_logged_in = true;
 $test_settings  = array();
-assert_same( '', extrachill_blog_get_default_event_location_slug(), 'Missing dependency field should fail open.' );
+assert_same( '', extrachill_blog_get_local_scene_slug(), 'Missing dependency field should fail open.' );
 
 $test_settings = array(
 	'default_event_location' => array(
 		'slug' => 'new-york-city',
 	),
 );
-assert_same( 'new-york-city', extrachill_blog_get_default_event_location_slug(), 'Resolved canonical preference slug should pass through unchanged.' );
+assert_same( '', extrachill_blog_get_local_scene_slug(), 'Compatibility aliases should not be consumed by Blog.' );
+
+$test_settings = array(
+	'local_scene' => array(
+		'slug' => 'new-york-city',
+	),
+);
+assert_same( 'new-york-city', extrachill_blog_get_local_scene_slug(), 'Resolved canonical local scene slug should pass through unchanged.' );
 
 fwrite( STDOUT, "Homepage event-market tests passed.\n" );


### PR DESCRIPTION
Moves homepage event personalization from the compatibility alias to the canonical Users-owned local_scene contract. Focused tests pass. Fixes #43.