### PR TITLE
fix: encode subscription status input

### DIFF
--- a/assets/js/festival-subscriptions.js
+++ b/assets/js/festival-subscriptions.js
@@ -23,7 +23,11 @@
 		};
 
 		if ( 'GET' === method ) {
-			url += '?input=' + encodeURIComponent( JSON.stringify( input ) );
+			const query = new URLSearchParams();
+			Object.keys( input ).forEach( function ( key ) {
+				query.set( 'input[' + key + ']', input[ key ] );
+			} );
+			url += '?' + query.toString();
 		} else {
 			options.headers['Content-Type'] = 'application/json';
 			options.body = JSON.stringify( { input: input } );


### PR DESCRIPTION
## Summary

- encode read-only ability input as nested `input[...]` query parameters
- preserve the existing JSON request body for subscribe and unsubscribe writes
- allow WordPress REST schema validation to receive the expected object

Fixes #49.

## Verification

- `node --check assets/js/festival-subscriptions.js`
- `git diff --check`