### PR TITLE
feat: add artist editorial routers

### DIFF
--- a/assets/css/entity-pillar.css
+++ b/assets/css/entity-pillar.css
@@ -1,11 +1,11 @@
-.festival-pillar-routes {
+.entity-pillar-routes {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 	gap: var(--spacing-md);
 	margin: var(--spacing-lg) 0 var(--spacing-xl);
 }
 
-.festival-pillar-route {
+.entity-pillar-route {
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing-xs);
@@ -20,23 +20,24 @@
 	transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.festival-pillar-route:hover,
-.festival-pillar-route:focus-visible {
+.entity-pillar-route:hover,
+.entity-pillar-route:focus-visible {
 	color: var(--text-color);
 	transform: translateY(-2px);
 	box-shadow: var(--card-hover-shadow);
 }
 
-.festival-pillar-route-events {
+.entity-pillar-route-events,
+.entity-pillar-route-shop {
 	border-left-color: var(--link-color);
 }
 
-.festival-pillar-route-community {
+.entity-pillar-route-community {
 	border-left-color: var(--accent-3);
 }
 
-.festival-pillar-route-kicker,
-.festival-pillar-coverage-header p {
+.entity-pillar-route-kicker,
+.entity-pillar-coverage-header p {
 	margin: 0;
 	color: var(--muted-text);
 	font-size: var(--font-size-sm);
@@ -45,25 +46,26 @@
 	text-transform: uppercase;
 }
 
-.festival-pillar-route strong {
+.entity-pillar-route strong {
 	font-family: var(--font-family-heading);
 	font-size: var(--font-size-xl);
 	line-height: var(--line-height-tight);
 }
 
-.festival-pillar-route > span:last-child {
+.entity-pillar-route > span:last-child,
+.entity-pillar-subscription-status {
 	color: var(--muted-text);
 }
 
-.festival-pillar-coverage-header {
+.entity-pillar-coverage-header {
 	margin: var(--spacing-xl) 0 var(--spacing-lg);
 }
 
-.festival-pillar-coverage-header h2 {
+.entity-pillar-coverage-header h2 {
 	margin: var(--spacing-xs) 0 0;
 }
 
-.festival-pillar-subscription {
+.entity-pillar-subscription {
 	margin: var(--spacing-lg) 0;
 	padding: var(--spacing-lg);
 	background: var(--card-background);
@@ -71,12 +73,12 @@
 	border-radius: var(--border-radius-lg);
 }
 
-.festival-pillar-subscription h2,
-.festival-pillar-subscription p {
+.entity-pillar-subscription h2,
+.entity-pillar-subscription p {
 	margin-top: 0;
 }
 
-.festival-pillar-subscription-button {
+.entity-pillar-subscription-button {
 	display: inline-block;
 	padding: 0.7rem 1rem;
 	color: var(--background-color);
@@ -89,31 +91,30 @@
 	border-radius: var(--border-radius);
 }
 
-.festival-pillar-subscription-button:hover,
-.festival-pillar-subscription-button:focus-visible {
+.entity-pillar-subscription-button:hover,
+.entity-pillar-subscription-button:focus-visible {
 	color: var(--background-color);
 	background: var(--accent-hover);
 	border-color: var(--accent-hover);
 }
 
-.festival-pillar-subscription-button[aria-pressed="true"] {
+.entity-pillar-subscription-button[aria-pressed="true"] {
 	color: var(--text-color);
 	background: transparent;
 	border-color: var(--text-color);
 }
 
-.festival-pillar-subscription-button:disabled {
+.entity-pillar-subscription-button:disabled {
 	cursor: wait;
 	opacity: 0.65;
 }
 
-.festival-pillar-subscription-status {
+.entity-pillar-subscription-status {
 	min-height: 1.5em;
 	margin-bottom: 0;
-	color: var(--muted-text);
 }
 
-.festival-pillar-newsletter {
+.entity-pillar-newsletter {
 	max-width: var(--content-width);
 	margin: var(--spacing-xl) auto;
 	padding: var(--spacing-xl);
@@ -124,18 +125,18 @@
 	box-shadow: var(--card-shadow);
 }
 
-.festival-pillar-newsletter h2 {
+.entity-pillar-newsletter h2 {
 	margin-top: 0;
 }
 
 @media (max-width: 600px) {
-	.festival-pillar-routes {
+	.entity-pillar-routes {
 		grid-template-columns: 1fr;
 	}
 
-	.festival-pillar-route,
-	.festival-pillar-newsletter,
-	.festival-pillar-subscription {
+	.entity-pillar-route,
+	.entity-pillar-newsletter,
+	.entity-pillar-subscription {
 		padding: var(--spacing-md);
 	}
 }

--- a/assets/js/entity-subscriptions.js
+++ b/assets/js/entity-subscriptions.js
@@ -1,12 +1,16 @@
 ( function () {
 	'use strict';
 
-	const buttons = document.querySelectorAll( '.festival-pillar-subscription-button[data-endpoint]' );
+	const buttons = document.querySelectorAll( '[data-entity-subscription][data-endpoint]' );
+
+	function getControl( button ) {
+		return button.closest( '[data-entity-subscription-control]' );
+	}
 
 	function setState( button, subscribed, message ) {
 		button.setAttribute( 'aria-pressed', subscribed ? 'true' : 'false' );
 		button.textContent = subscribed ? 'Subscribed to updates' : 'Subscribe to updates';
-		button.closest( '.festival-pillar-subscription' ).querySelector( '.festival-pillar-subscription-status' ).textContent = message || '';
+		getControl( button ).querySelector( '.entity-pillar-subscription-status' ).textContent = message || '';
 	}
 
 	function request( button, ability, method ) {
@@ -47,7 +51,7 @@
 		request( button, 'entity-subscription-status', 'GET' ).then( function ( data ) {
 			setState( button, Boolean( data.subscribed ) );
 		} ).catch( function () {
-			button.closest( '.festival-pillar-subscription' ).querySelector( '.festival-pillar-subscription-status' ).textContent = 'Subscription status is unavailable. Please try again.';
+			getControl( button ).querySelector( '.entity-pillar-subscription-status' ).textContent = 'Subscription status is unavailable. Please try again.';
 		} ).finally( function () {
 			button.disabled = false;
 		} );
@@ -56,9 +60,9 @@
 			const subscribed = 'true' === button.getAttribute( 'aria-pressed' );
 			button.disabled = true;
 			request( button, subscribed ? 'entity-unsubscribe' : 'entity-subscribe', 'POST' ).then( function ( data ) {
-				setState( button, Boolean( data.subscribed ), data.subscribed ? 'You will receive festival updates.' : 'You will no longer receive festival updates.' );
+				setState( button, Boolean( data.subscribed ), data.subscribed ? 'You will receive updates.' : 'You will no longer receive updates.' );
 			} ).catch( function () {
-				button.closest( '.festival-pillar-subscription' ).querySelector( '.festival-pillar-subscription-status' ).textContent = 'Unable to update your subscription. Please try again.';
+				getControl( button ).querySelector( '.entity-pillar-subscription-status' ).textContent = 'Unable to update your subscription. Please try again.';
 			} ).finally( function () {
 				button.disabled = false;
 			} );

--- a/extrachill-blog.php
+++ b/extrachill-blog.php
@@ -36,6 +36,7 @@ require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/blog-archive-routing.php'
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/breadcrumbs.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/festival-pillar.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/festival-subscriptions.php';
+require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/artist-pillar.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/share-card.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/network-bridge.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/login-register-cta.php';
@@ -54,24 +55,24 @@ function extrachill_blog_register_styles() {
 		$version
 	);
 
-	$festival_version = filemtime( EXTRACHILL_BLOG_PLUGIN_DIR . 'assets/css/festival-pillar.css' );
-	$festival_version = false === $festival_version ? null : (string) $festival_version;
+	$entity_pillar_version = filemtime( EXTRACHILL_BLOG_PLUGIN_DIR . 'assets/css/entity-pillar.css' );
+	$entity_pillar_version = false === $entity_pillar_version ? null : (string) $entity_pillar_version;
 
 	wp_register_style(
-		'extrachill-blog-festival-pillar',
-		EXTRACHILL_BLOG_PLUGIN_URL . 'assets/css/festival-pillar.css',
+		'extrachill-blog-entity-pillar',
+		EXTRACHILL_BLOG_PLUGIN_URL . 'assets/css/entity-pillar.css',
 		array( 'extrachill-root' ),
-		$festival_version
+		$entity_pillar_version
 	);
 
-	$festival_script_version = filemtime( EXTRACHILL_BLOG_PLUGIN_DIR . 'assets/js/festival-subscriptions.js' );
-	$festival_script_version = false === $festival_script_version ? null : (string) $festival_script_version;
+	$entity_subscription_version = filemtime( EXTRACHILL_BLOG_PLUGIN_DIR . 'assets/js/entity-subscriptions.js' );
+	$entity_subscription_version = false === $entity_subscription_version ? null : (string) $entity_subscription_version;
 
 	wp_register_script(
-		'extrachill-blog-festival-subscriptions',
-		EXTRACHILL_BLOG_PLUGIN_URL . 'assets/js/festival-subscriptions.js',
+		'extrachill-blog-entity-subscriptions',
+		EXTRACHILL_BLOG_PLUGIN_URL . 'assets/js/entity-subscriptions.js',
 		array(),
-		$festival_script_version,
+		$entity_subscription_version,
 		true
 	);
 }

--- a/inc/archive/artist-pillar.php
+++ b/inc/archive/artist-pillar.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Main-site artist editorial router.
+ *
+ * Artist Platform owns profiles. This archive only connects editorial coverage
+ * to the published destinations already resolved by the Network layer.
+ *
+ * @package ExtraChillBlog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Check whether the current request is a main-site artist archive.
+ *
+ * @return bool
+ */
+function extrachill_blog_is_artist_pillar() {
+	return extrachill_blog_is_main_taxonomy_archive( 'artist' );
+}
+
+/**
+ * Prepare the artist editorial router without changing the native archive loop.
+ *
+ * @return void
+ */
+function extrachill_blog_prepare_artist_pillar() {
+	if ( ! extrachill_blog_is_artist_pillar() ) {
+		return;
+	}
+
+	remove_action( 'extrachill_archive_below_description', 'extrachill_render_cross_site_taxonomy_links' );
+	wp_enqueue_style( 'extrachill-blog-entity-pillar' );
+}
+add_action( 'wp', 'extrachill_blog_prepare_artist_pillar' );
+
+/**
+ * Render only the artist's live cross-site destinations.
+ *
+ * @return void
+ */
+function extrachill_blog_render_artist_network_routes() {
+	if ( ! extrachill_blog_is_artist_pillar() || ! function_exists( 'extrachill_get_cross_site_term_links' ) ) {
+		return;
+	}
+
+	$term = get_queried_object();
+	if ( ! ( $term instanceof WP_Term ) ) {
+		return;
+	}
+
+	$links = array();
+	foreach ( extrachill_get_cross_site_term_links( $term, 'artist' ) as $link ) {
+		if ( ! empty( $link['site_key'] ) ) {
+			$links[ $link['site_key'] ] = $link;
+		}
+	}
+
+	$destinations = array(
+		'artist'    => array(
+			'label'       => __( 'Artist Platform', 'extrachill-blog' ),
+			'description' => __( 'Official artist profile', 'extrachill-blog' ),
+		),
+		'events'    => array(
+			'label'       => __( 'Events', 'extrachill-blog' ),
+			'description' => __( 'Upcoming shows', 'extrachill-blog' ),
+		),
+		'community' => array(
+			'label'       => __( 'Community', 'extrachill-blog' ),
+			'description' => __( 'Artist discussions', 'extrachill-blog' ),
+		),
+		'shop'      => array(
+			'label'       => __( 'Shop', 'extrachill-blog' ),
+			'description' => __( 'Artist merchandise', 'extrachill-blog' ),
+		),
+	);
+	$links        = array_intersect_key( $links, $destinations );
+	if ( empty( $links ) ) {
+		return;
+	}
+	?>
+	<?php /* translators: %s: artist name. */ ?>
+	<nav class="entity-pillar-routes" aria-label="<?php echo esc_attr( sprintf( __( '%s across Extra Chill', 'extrachill-blog' ), $term->name ) ); ?>">
+		<?php foreach ( $destinations as $site_key => $destination ) : ?>
+			<?php if ( empty( $links[ $site_key ] ) ) : ?>
+				<?php continue; ?>
+			<?php endif; ?>
+			<a class="entity-pillar-route entity-pillar-route-<?php echo esc_attr( $site_key ); ?>" href="<?php echo esc_url( $links[ $site_key ]['url'] ); ?>">
+				<span class="entity-pillar-route-kicker"><?php echo esc_html( $destination['label'] ); ?></span>
+				<strong><?php echo esc_html( $destination['description'] ); ?></strong>
+			</a>
+		<?php endforeach; ?>
+	</nav>
+	<?php
+}
+add_action( 'extrachill_archive_below_description', 'extrachill_blog_render_artist_network_routes' );
+
+/**
+ * Frame the native archive loop as editorial coverage.
+ *
+ * @return void
+ */
+function extrachill_blog_render_artist_coverage_heading() {
+	if ( ! extrachill_blog_is_artist_pillar() ) {
+		return;
+	}
+
+	$term = get_queried_object();
+	if ( ! ( $term instanceof WP_Term ) ) {
+		return;
+	}
+
+	printf(
+		'<header class="entity-pillar-coverage-header"><p>%s</p><h2>%s</h2></header>',
+		esc_html__( 'From the publication', 'extrachill-blog' ),
+		/* translators: %s: artist name. */
+		esc_html( sprintf( __( 'Extra Chill coverage of %s', 'extrachill-blog' ), $term->name ) )
+	);
+}
+add_action( 'extrachill_archive_above_posts', 'extrachill_blog_render_artist_coverage_heading', 20 );
+
+/**
+ * Render the private artist subscription control.
+ *
+ * @return void
+ */
+function extrachill_blog_render_artist_subscription_control() {
+	if ( ! extrachill_blog_is_artist_pillar() || is_paged() ) {
+		return;
+	}
+
+	$term = get_queried_object();
+	if ( ! ( $term instanceof WP_Term ) ) {
+		return;
+	}
+
+	if ( ! is_user_logged_in() ) {
+		?>
+		<section class="entity-pillar-subscription" aria-labelledby="artist-pillar-subscription-title">
+			<h2 id="artist-pillar-subscription-title"><?php esc_html_e( 'Get artist updates', 'extrachill-blog' ); ?></h2>
+			<p><?php esc_html_e( 'Log in to subscribe to private Extra Chill notifications for this artist.', 'extrachill-blog' ); ?></p>
+			<a class="entity-pillar-subscription-button" href="<?php echo esc_url( wp_login_url( get_term_link( $term ) ) ); ?>"><?php esc_html_e( 'Log in to subscribe', 'extrachill-blog' ); ?></a>
+		</section>
+		<?php
+		return;
+	}
+
+	wp_enqueue_script( 'extrachill-blog-entity-subscriptions' );
+	?>
+	<section class="entity-pillar-subscription" data-entity-subscription-control aria-labelledby="artist-pillar-subscription-title">
+		<h2 id="artist-pillar-subscription-title"><?php esc_html_e( 'Get artist updates', 'extrachill-blog' ); ?></h2>
+		<p><?php esc_html_e( 'Subscribe to private Extra Chill notifications for new editorial coverage of this artist.', 'extrachill-blog' ); ?></p>
+		<button
+			class="entity-pillar-subscription-button"
+			type="button"
+			aria-pressed="false"
+			disabled
+			data-entity-subscription
+			data-entity-type="artist"
+			data-taxonomy="artist"
+			data-slug="<?php echo esc_attr( $term->slug ); ?>"
+			data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>"
+			data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>"
+		>
+			<?php esc_html_e( 'Subscribe to updates', 'extrachill-blog' ); ?>
+		</button>
+		<p class="entity-pillar-subscription-status" aria-live="polite"></p>
+	</section>
+	<?php
+}
+add_action( 'extrachill_archive_below_description', 'extrachill_blog_render_artist_subscription_control', 5 );

--- a/inc/archive/festival-pillar.php
+++ b/inc/archive/festival-pillar.php
@@ -10,16 +10,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Check whether the current request is a main-site taxonomy archive.
+ *
+ * @param string $taxonomy Taxonomy slug.
+ * @return bool
+ */
+function extrachill_blog_is_main_taxonomy_archive( $taxonomy ) {
+	$is_main_site = function_exists( 'ec_get_current_site_key' )
+		? 'main' === ec_get_current_site_key()
+		: 1 === (int) get_current_blog_id();
+
+	return $is_main_site && is_tax( $taxonomy );
+}
+
+/**
  * Check whether the current request is a main-site festival archive.
  *
  * @return bool
  */
 function extrachill_blog_is_festival_pillar() {
-	$is_main_site = function_exists( 'ec_get_current_site_key' )
-		? 'main' === ec_get_current_site_key()
-		: 1 === (int) get_current_blog_id();
-
-	return $is_main_site && is_tax( 'festival' );
+	return extrachill_blog_is_main_taxonomy_archive( 'festival' );
 }
 
 /**
@@ -33,7 +43,7 @@ function extrachill_blog_prepare_festival_pillar() {
 	}
 
 	remove_action( 'extrachill_archive_below_description', 'extrachill_render_cross_site_taxonomy_links' );
-	wp_enqueue_style( 'extrachill-blog-festival-pillar' );
+	wp_enqueue_style( 'extrachill-blog-entity-pillar' );
 }
 add_action( 'wp', 'extrachill_blog_prepare_festival_pillar' );
 
@@ -79,26 +89,26 @@ function extrachill_blog_render_festival_network_routes() {
 	/* translators: %s: number of Community topics. */
 	$community_count = ! empty( $links['community'] ) ? sprintf( _n( '%s festival discussion', '%s festival discussions', (int) $links['community']['count'], 'extrachill-blog' ), number_format_i18n( (int) $links['community']['count'] ) ) : '';
 	?>
-	<nav class="festival-pillar-routes" aria-label="<?php echo esc_attr( $navigation_label ); ?>">
+	<nav class="entity-pillar-routes" aria-label="<?php echo esc_attr( $navigation_label ); ?>">
 		<?php if ( ! empty( $links['wire'] ) ) : ?>
-			<a class="festival-pillar-route festival-pillar-route-wire" href="<?php echo esc_url( $links['wire']['url'] ); ?>">
-				<span class="festival-pillar-route-kicker"><?php esc_html_e( 'Festival Wire', 'extrachill-blog' ); ?></span>
+			<a class="entity-pillar-route entity-pillar-route-wire" href="<?php echo esc_url( $links['wire']['url'] ); ?>">
+				<span class="entity-pillar-route-kicker"><?php esc_html_e( 'Festival Wire', 'extrachill-blog' ); ?></span>
 				<strong><?php echo esc_html( $wire_title ); ?></strong>
 				<span><?php echo esc_html( $wire_count ); ?></span>
 			</a>
 		<?php endif; ?>
 
 		<?php if ( ! empty( $links['events'] ) ) : ?>
-			<a class="festival-pillar-route festival-pillar-route-events" href="<?php echo esc_url( $links['events']['url'] ); ?>">
-				<span class="festival-pillar-route-kicker"><?php esc_html_e( 'Events', 'extrachill-blog' ); ?></span>
+			<a class="entity-pillar-route entity-pillar-route-events" href="<?php echo esc_url( $links['events']['url'] ); ?>">
+				<span class="entity-pillar-route-kicker"><?php esc_html_e( 'Events', 'extrachill-blog' ); ?></span>
 				<strong><?php echo esc_html( $events_title ); ?></strong>
 				<span><?php echo esc_html( $events_count ); ?></span>
 			</a>
 		<?php endif; ?>
 
 		<?php if ( ! empty( $links['community'] ) ) : ?>
-			<a class="festival-pillar-route festival-pillar-route-community" href="<?php echo esc_url( $links['community']['url'] ); ?>">
-				<span class="festival-pillar-route-kicker"><?php esc_html_e( 'Community', 'extrachill-blog' ); ?></span>
+			<a class="entity-pillar-route entity-pillar-route-community" href="<?php echo esc_url( $links['community']['url'] ); ?>">
+				<span class="entity-pillar-route-kicker"><?php esc_html_e( 'Community', 'extrachill-blog' ); ?></span>
 				<strong><?php echo esc_html( $community_title ); ?></strong>
 				<span><?php echo esc_html( $community_count ); ?></span>
 			</a>
@@ -124,7 +134,7 @@ function extrachill_blog_render_festival_coverage_heading() {
 	}
 
 	printf(
-		'<header class="festival-pillar-coverage-header"><p>%s</p><h2>%s</h2></header>',
+		'<header class="entity-pillar-coverage-header"><p>%s</p><h2>%s</h2></header>',
 		esc_html__( 'From the publication', 'extrachill-blog' ),
 		/* translators: %s: festival name. */
 		esc_html( sprintf( __( 'Extra Chill coverage of %s', 'extrachill-blog' ), $term->name ) )
@@ -142,7 +152,7 @@ function extrachill_blog_render_festival_newsletter() {
 		return;
 	}
 	?>
-	<section class="festival-pillar-newsletter" aria-labelledby="festival-pillar-newsletter-title">
+	<section class="entity-pillar-newsletter" aria-labelledby="festival-pillar-newsletter-title">
 		<h2 id="festival-pillar-newsletter-title"><?php esc_html_e( 'Stay in the festival loop', 'extrachill-blog' ); ?></h2>
 		<p><?php esc_html_e( 'Get music news, festival updates, and the best of Extra Chill delivered to your inbox.', 'extrachill-blog' ); ?></p>
 		<?php do_action( 'extrachill_render_newsletter_form', 'archive' ); ?>

--- a/inc/archive/festival-subscriptions.php
+++ b/inc/archive/festival-subscriptions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Festival pillar subscription controls and publication notifications.
+ * Entity pillar subscription controls and publication notifications.
  *
  * @package ExtraChillBlog
  */
@@ -9,8 +9,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_PRODUCER      = 'extrachill-blog';
+const EXTRACHILL_BLOG_ENTITY_SUBSCRIPTION_PRODUCER        = 'extrachill-blog';
 const EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_NOTIFIED_META = '_extrachill_blog_festival_subscriptions_notified';
+const EXTRACHILL_BLOG_ARTIST_SUBSCRIPTION_NOTIFIED_META   = '_extrachill_blog_artist_subscriptions_notified';
 
 /**
  * Allow this plugin to resolve private festival subscription recipients.
@@ -20,7 +21,7 @@ const EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_NOTIFIED_META = '_extrachill_blog_fe
  * @return bool
  */
 function extrachill_blog_authorize_festival_subscription_producer( $authorized, $producer ) {
-	return $authorized || EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_PRODUCER === $producer;
+	return $authorized || EXTRACHILL_BLOG_ENTITY_SUBSCRIPTION_PRODUCER === $producer;
 }
 add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrachill_blog_authorize_festival_subscription_producer', 10, 2 );
 
@@ -41,38 +42,52 @@ function extrachill_blog_render_festival_subscription_control() {
 
 	if ( ! is_user_logged_in() ) {
 		?>
-		<section class="festival-pillar-subscription" aria-labelledby="festival-pillar-subscription-title">
+		<section class="entity-pillar-subscription" aria-labelledby="festival-pillar-subscription-title">
 			<h2 id="festival-pillar-subscription-title"><?php esc_html_e( 'Get festival updates', 'extrachill-blog' ); ?></h2>
 			<p><?php esc_html_e( 'Log in to subscribe to private Extra Chill notifications for this festival.', 'extrachill-blog' ); ?></p>
-			<a class="festival-pillar-subscription-button" href="<?php echo esc_url( wp_login_url( get_term_link( $term ) ) ); ?>"><?php esc_html_e( 'Log in to subscribe', 'extrachill-blog' ); ?></a>
+			<a class="entity-pillar-subscription-button" href="<?php echo esc_url( wp_login_url( get_term_link( $term ) ) ); ?>"><?php esc_html_e( 'Log in to subscribe', 'extrachill-blog' ); ?></a>
 		</section>
 		<?php
 		return;
 	}
 
-	wp_enqueue_script( 'extrachill-blog-festival-subscriptions' );
+	wp_enqueue_script( 'extrachill-blog-entity-subscriptions' );
 	?>
-	<section class="festival-pillar-subscription" aria-labelledby="festival-pillar-subscription-title">
+	<section class="entity-pillar-subscription" data-entity-subscription-control aria-labelledby="festival-pillar-subscription-title">
 		<h2 id="festival-pillar-subscription-title"><?php esc_html_e( 'Get festival updates', 'extrachill-blog' ); ?></h2>
 		<p><?php esc_html_e( 'Subscribe to private Extra Chill notifications for new editorial coverage of this festival.', 'extrachill-blog' ); ?></p>
 		<button
-			class="festival-pillar-subscription-button"
+			class="entity-pillar-subscription-button"
 			type="button"
 			aria-pressed="false"
 			disabled
 			data-entity-type="festival"
 			data-taxonomy="festival"
+			data-entity-subscription
 			data-slug="<?php echo esc_attr( $term->slug ); ?>"
 			data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>"
 			data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>"
 		>
 			<?php esc_html_e( 'Subscribe to updates', 'extrachill-blog' ); ?>
 		</button>
-		<p class="festival-pillar-subscription-status" aria-live="polite"></p>
+		<p class="entity-pillar-subscription-status" aria-live="polite"></p>
 	</section>
 	<?php
 }
 add_action( 'extrachill_archive_below_description', 'extrachill_blog_render_festival_subscription_control', 5 );
+
+/**
+ * Get canonical entity terms assigned to a main editorial post.
+ *
+ * @param int    $post_id  Post ID.
+ * @param string $taxonomy Taxonomy slug.
+ * @return WP_Term[] Entity terms.
+ */
+function extrachill_blog_get_post_entity_terms( $post_id, $taxonomy ) {
+	$terms = wp_get_post_terms( $post_id, $taxonomy );
+
+	return is_wp_error( $terms ) ? array() : $terms;
+}
 
 /**
  * Get canonical festival terms assigned to a main editorial post.
@@ -81,20 +96,22 @@ add_action( 'extrachill_archive_below_description', 'extrachill_blog_render_fest
  * @return WP_Term[] Festival terms.
  */
 function extrachill_blog_get_post_festival_terms( $post_id ) {
-	$terms = wp_get_post_terms( $post_id, 'festival' );
-
-	return is_wp_error( $terms ) ? array() : $terms;
+	return extrachill_blog_get_post_entity_terms( $post_id, 'festival' );
 }
 
 /**
- * Notify unique festival subscribers only when a main post first publishes.
+ * Notify unique entity subscribers only when a main post first publishes.
  *
- * @param string  $new_status New post status.
- * @param string  $old_status Previous post status.
- * @param WP_Post $post       Published post.
+ * @param string  $new_status         New post status.
+ * @param string  $old_status         Previous post status.
+ * @param WP_Post $post               Published post.
+ * @param string  $entity_type        Entity type and taxonomy slug.
+ * @param string  $notification_type  Notification type.
+ * @param string  $notification_title Translated notification title template.
+ * @param string  $notified_meta      Post meta key that claims first publication.
  * @return void
  */
-function extrachill_blog_notify_festival_subscribers( $new_status, $old_status, $post ) {
+function extrachill_blog_notify_entity_subscribers( $new_status, $old_status, $post, $entity_type, $notification_type, $notification_title, $notified_meta ) {
 	if ( 'publish' !== $new_status || 'publish' === $old_status || ! is_object( $post ) || 'post' !== $post->post_type ) {
 		return;
 	}
@@ -105,11 +122,11 @@ function extrachill_blog_notify_festival_subscribers( $new_status, $old_status, 
 		return;
 	}
 
-	if ( get_post_meta( $post->ID, EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_NOTIFIED_META, true ) ) {
+	if ( get_post_meta( $post->ID, $notified_meta, true ) ) {
 		return;
 	}
 
-	$terms = extrachill_blog_get_post_festival_terms( $post->ID );
+	$terms = extrachill_blog_get_post_entity_terms( $post->ID, $entity_type );
 	if ( empty( $terms ) || ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify' ) ) {
 		return;
 	}
@@ -121,9 +138,9 @@ function extrachill_blog_notify_festival_subscribers( $new_status, $old_status, 
 		}
 
 		$recipients = extrachill_users_entity_subscription_recipients(
-			EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_PRODUCER,
-			'festival',
-			'festival',
+			EXTRACHILL_BLOG_ENTITY_SUBSCRIPTION_PRODUCER,
+			$entity_type,
+			$entity_type,
 			$term->slug
 		);
 		if ( ! is_wp_error( $recipients ) ) {
@@ -134,7 +151,7 @@ function extrachill_blog_notify_festival_subscribers( $new_status, $old_status, 
 	$recipient_ids = array_values( array_unique( array_map( 'absint', $recipient_ids ) ) );
 	$recipient_ids = array_filter( $recipient_ids );
 	if ( empty( $recipient_ids ) ) {
-		update_post_meta( $post->ID, EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_NOTIFIED_META, current_time( 'mysql', true ) );
+		update_post_meta( $post->ID, $notified_meta, current_time( 'mysql', true ) );
 		return;
 	}
 
@@ -146,19 +163,64 @@ function extrachill_blog_notify_festival_subscribers( $new_status, $old_status, 
 		return;
 	}
 
+	// Claim before delivery so concurrent publish hooks cannot duplicate notices.
+	if ( ! add_post_meta( $post->ID, $notified_meta, current_time( 'mysql', true ), true ) ) {
+		return;
+	}
+
 	ec_users_notify(
 		$recipient_ids,
 		array(
 			'actor_id' => $actor_id,
-			'type'     => 'festival_update',
+			'type'     => $notification_type,
 			/* translators: %s: post title. */
-			'title'    => sprintf( __( 'New festival update: %s', 'extrachill-blog' ), get_the_title( $post ) ),
+			'title'    => sprintf( $notification_title, get_the_title( $post ) ),
 			'link'     => get_permalink( $post ),
 			'item_id'  => (int) $post->ID,
 		)
 	);
+}
 
-	// Guard re-publishes and later edits after the initial notification attempt.
-	update_post_meta( $post->ID, EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_NOTIFIED_META, current_time( 'mysql', true ) );
+/**
+ * Notify festival subscribers only when a main post first publishes.
+ *
+ * @param string  $new_status New post status.
+ * @param string  $old_status Previous post status.
+ * @param WP_Post $post       Published post.
+ * @return void
+ */
+function extrachill_blog_notify_festival_subscribers( $new_status, $old_status, $post ) {
+	extrachill_blog_notify_entity_subscribers(
+		$new_status,
+		$old_status,
+		$post,
+		'festival',
+		'festival_update',
+		/* translators: %s: post title. */
+		__( 'New festival update: %s', 'extrachill-blog' ),
+		EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_NOTIFIED_META
+	);
 }
 add_action( 'transition_post_status', 'extrachill_blog_notify_festival_subscribers', 10, 3 );
+
+/**
+ * Notify artist subscribers only when a main post first publishes.
+ *
+ * @param string  $new_status New post status.
+ * @param string  $old_status Previous post status.
+ * @param WP_Post $post       Published post.
+ * @return void
+ */
+function extrachill_blog_notify_artist_subscribers( $new_status, $old_status, $post ) {
+	extrachill_blog_notify_entity_subscribers(
+		$new_status,
+		$old_status,
+		$post,
+		'artist',
+		'artist_update',
+		/* translators: %s: post title. */
+		__( 'New artist update: %s', 'extrachill-blog' ),
+		EXTRACHILL_BLOG_ARTIST_SUBSCRIPTION_NOTIFIED_META
+	);
+}
+add_action( 'transition_post_status', 'extrachill_blog_notify_artist_subscribers', 10, 3 );

--- a/tests/festival-subscriptions.php
+++ b/tests/festival-subscriptions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Focused smoke coverage for festival subscription notifications.
+ * Focused smoke coverage for entity subscription notifications.
  *
  * Run with: php tests/festival-subscriptions.php
  */
@@ -23,7 +23,11 @@ function add_filter() {}
 function is_wp_error() {
 	return false;
 }
-function wp_get_post_terms() {
+function wp_get_post_terms( $post_id, $taxonomy ) {
+	if ( 'artist' === $taxonomy ) {
+		return array( new WP_Term( 'artist-one' ), new WP_Term( 'artist-two' ) );
+	}
+
 	return array( new WP_Term( 'festival-one' ), new WP_Term( 'festival-two' ) );
 }
 function get_post_meta( $post_id, $key ) {
@@ -33,6 +37,14 @@ function get_post_meta( $post_id, $key ) {
 function update_post_meta( $post_id, $key, $value ) {
 	global $test_meta;
 	$test_meta[ $post_id ][ $key ] = $value;
+}
+function add_post_meta( $post_id, $key, $value, $unique ) {
+	global $test_meta;
+	if ( $unique && isset( $test_meta[ $post_id ][ $key ] ) ) {
+		return false;
+	}
+	$test_meta[ $post_id ][ $key ] = $value;
+	return true;
 }
 function current_time() {
 	return '2026-07-12 20:00:00';
@@ -56,10 +68,10 @@ function __( $text ) {
 	return $text;
 }
 function extrachill_users_entity_subscription_recipients( $producer, $entity_type, $taxonomy, $slug ) {
-	if ( 'extrachill-blog' !== $producer || 'festival' !== $entity_type || 'festival' !== $taxonomy ) {
+	if ( 'extrachill-blog' !== $producer || $entity_type !== $taxonomy ) {
 		return array();
 	}
-	return 'festival-one' === $slug ? array( 4, 7 ) : array( 7, 9 );
+	return '-one' === substr( $slug, -4 ) ? array( 4, 7 ) : array( 7, 9 );
 }
 function ec_users_notify( $recipient_ids, $data ) {
 	global $test_notifications;
@@ -95,4 +107,18 @@ assert_same( 'festival_update', $test_notifications[0]['data']['type'], 'Festiva
 extrachill_blog_notify_festival_subscribers( 'publish', 'draft', $post );
 assert_same( 1, count( $test_notifications ), 'Publish guard must prevent duplicate notifications.' );
 
-fwrite( STDOUT, "Festival subscription tests passed.\n" );
+$artist_post = (object) array(
+	'ID'          => 47,
+	'post_type'   => 'post',
+	'post_author' => 12,
+);
+
+extrachill_blog_notify_artist_subscribers( 'publish', 'draft', $artist_post );
+assert_same( 2, count( $test_notifications ), 'First artist publication should notify subscribers once.' );
+assert_same( array( 4, 7, 9 ), $test_notifications[1]['recipient_ids'], 'Artist recipients from multiple terms must be unique.' );
+assert_same( 'artist_update', $test_notifications[1]['data']['type'], 'Artist updates must use their dedicated notification type.' );
+
+extrachill_blog_notify_artist_subscribers( 'publish', 'draft', $artist_post );
+assert_same( 2, count( $test_notifications ), 'Artist publish guard must prevent duplicate notifications.' );
+
+fwrite( STDOUT, "Entity subscription tests passed.\n" );


### PR DESCRIPTION
## Summary
- Treat main-site artist archives as editorial routers: preserve the native archive loop, show only live Artist Platform, Events, Community, and Shop destinations from the Network cross-site term resolver, and keep Artist Platform as the canonical profile owner.
- Extract the proven festival pillar browser control into a shared private entity-subscription adapter, then add truthful artist login/status/toggle behavior without exposing recipient counts.
- Extend Blog's first-publication entity producer to notify de-duplicated private artist subscribers for explicitly artist-tagged main posts while retaining festival behavior; the notification claim prevents concurrent duplicate delivery.

## Ownership
- No artist profile fields, profile URLs, or identity data are duplicated in Blog. `extrachill_get_cross_site_term_links()` remains the source of live route resolution, including Artist Platform's canonical `artist_profile` lookup.
- The shared entity subscription UI is intentionally limited to the existing festival and artist consumers, not new generic infrastructure.

## Testing
- `php -l extrachill-blog.php inc/archive/festival-pillar.php inc/archive/festival-subscriptions.php inc/archive/artist-pillar.php`
- `php tests/homepage-event-markets.php`
- `php tests/festival-subscriptions.php`
- `vendor/bin/phpcs --standard=WordPress extrachill-blog.php inc/archive/festival-pillar.php inc/archive/festival-subscriptions.php inc/archive/artist-pillar.php`
- `composer test` runs both smoke tests successfully but exits non-zero on pre-existing WordPress coding-standard violations in `inc/single/login-register-cta.php`, `inc/core/co-authors.php`, `inc/core/ads-filter.php`, and `inc/core/admin-customizations.php`.

Closes #51