### PR TITLE
fix: improve artist activity timeline

### DIFF
--- a/assets/css/entity-pillar.css
+++ b/assets/css/entity-pillar.css
@@ -78,26 +78,6 @@
 	margin-top: 0;
 }
 
-.entity-pillar-subscription-button {
-	display: inline-block;
-	padding: 0.7rem 1rem;
-	color: var(--background-color);
-	font: inherit;
-	font-weight: 700;
-	text-decoration: none;
-	cursor: pointer;
-	background: var(--accent);
-	border: 1px solid var(--accent);
-	border-radius: var(--border-radius);
-}
-
-.entity-pillar-subscription-button:hover,
-.entity-pillar-subscription-button:focus-visible {
-	color: var(--background-color);
-	background: var(--accent-hover);
-	border-color: var(--accent-hover);
-}
-
 .entity-pillar-subscription-button[aria-pressed="true"] {
 	color: var(--text-color);
 	background: transparent;
@@ -155,6 +135,13 @@
 	font-family: var(--font-family-heading);
 	font-size: var(--font-size-lg);
 	font-weight: 700;
+}
+
+.entity-pillar-activity-context {
+	display: block;
+	margin-top: var(--spacing-xs);
+	color: var(--muted-text);
+	font-size: var(--font-size-sm);
 }
 
 .entity-pillar-newsletter {

--- a/inc/archive/artist-pillar.php
+++ b/inc/archive/artist-pillar.php
@@ -201,12 +201,20 @@ function extrachill_blog_get_artist_events_activity( $term ) {
 
 	$items = array();
 	foreach ( array_merge( $result['upcoming'] ?? array(), $result['past'] ?? array() ) as $event ) {
-		$items[] = extrachill_blog_build_artist_activity_item(
+		$event_context = array_filter(
+			array(
+				isset( $event['venue_name'] ) ? $event['venue_name'] : '',
+				isset( $event['time_display'] ) ? $event['time_display'] : '',
+			)
+		);
+		$items[]       = extrachill_blog_build_artist_activity_item(
 			isset( $event['title'] ) ? $event['title'] : '',
 			isset( $event['permalink'] ) ? $event['permalink'] : '',
 			isset( $event['date_iso'] ) ? $event['date_iso'] : '',
 			__( 'Events', 'extrachill-blog' ),
-			isset( $event['date_display'] ) ? $event['date_display'] : ''
+			isset( $event['date_display'] ) ? $event['date_display'] : '',
+			implode( ', ', $event_context ),
+			isset( $event['timing'] ) ? $event['timing'] : ''
 		);
 	}
 
@@ -256,7 +264,7 @@ function extrachill_blog_get_artist_community_activity( $term ) {
 		foreach ( $topics as $topic ) {
 			$items[] = extrachill_blog_build_artist_activity_item(
 				get_the_title( $topic ),
-				get_permalink( $topic ),
+				extrachill_blog_get_artist_community_topic_permalink( $topic ),
 				get_post_time( 'c', true, $topic ),
 				__( 'Community discussion', 'extrachill-blog' )
 			);
@@ -266,6 +274,21 @@ function extrachill_blog_get_artist_community_activity( $term ) {
 	}
 
 	return array_filter( $items );
+}
+
+/**
+ * Resolve a Community topic's canonical bbPress permalink.
+ *
+ * @param WP_Post $topic Community topic post.
+ * @return string Canonical topic URL.
+ */
+function extrachill_blog_get_artist_community_topic_permalink( $topic ) {
+	$topic_id = $topic instanceof WP_Post ? (int) $topic->ID : 0;
+	if ( $topic_id && function_exists( 'bbp_get_topic_permalink' ) ) {
+		return bbp_get_topic_permalink( $topic_id );
+	}
+
+	return $topic_id ? get_permalink( $topic_id ) : '';
 }
 
 /**
@@ -322,9 +345,11 @@ function extrachill_blog_get_artist_platform_activity( $term ) {
  * @param string $date         ISO-compatible date.
  * @param string $source       Source label.
  * @param string $date_display Source-formatted date, when available.
+ * @param string $context      Source-owned venue and time context, when available.
+ * @param string $timing       Source-owned upcoming or past timing, when available.
  * @return array|null Activity item.
  */
-function extrachill_blog_build_artist_activity_item( $title, $url, $date, $source, $date_display = '' ) {
+function extrachill_blog_build_artist_activity_item( $title, $url, $date, $source, $date_display = '', $context = '', $timing = '' ) {
 	$timestamp = strtotime( $date );
 	if ( '' === $title || '' === $url || ! $timestamp ) {
 		return null;
@@ -336,6 +361,8 @@ function extrachill_blog_build_artist_activity_item( $title, $url, $date, $sourc
 		'date'         => gmdate( 'c', $timestamp ),
 		'date_display' => '' !== $date_display ? (string) $date_display : wp_date( get_option( 'date_format' ), $timestamp ),
 		'source'       => (string) $source,
+		'context'      => (string) $context,
+		'timing'       => (string) $timing,
 		'timestamp'    => $timestamp,
 	);
 }
@@ -384,8 +411,11 @@ function extrachill_blog_render_artist_activity() {
 				<li class="entity-pillar-activity-item">
 					<time datetime="<?php echo esc_attr( $item['date'] ); ?>"><?php echo esc_html( $item['date_display'] ); ?></time>
 					<div>
-						<p><?php echo esc_html( $item['source'] ); ?></p>
+						<p><?php echo esc_html( $item['source'] ); ?><?php echo ! empty( $item['timing'] ) ? esc_html( ' - ' . ucfirst( $item['timing'] ) ) : ''; ?></p>
 						<a href="<?php echo esc_url( $item['url'] ); ?>"><?php echo esc_html( $item['title'] ); ?></a>
+						<?php if ( ! empty( $item['context'] ) ) : ?>
+							<span class="entity-pillar-activity-context"><?php echo esc_html( $item['context'] ); ?></span>
+						<?php endif; ?>
 					</div>
 				</li>
 			<?php endforeach; ?>
@@ -439,7 +469,7 @@ function extrachill_blog_render_artist_subscription_control() {
 		<section class="entity-pillar-subscription" aria-labelledby="artist-pillar-subscription-title">
 			<h2 id="artist-pillar-subscription-title"><?php esc_html_e( 'Get artist updates', 'extrachill-blog' ); ?></h2>
 			<p><?php esc_html_e( 'Log in to subscribe to private Extra Chill notifications for this artist.', 'extrachill-blog' ); ?></p>
-			<a class="entity-pillar-subscription-button" href="<?php echo esc_url( wp_login_url( get_term_link( $term ) ) ); ?>"><?php esc_html_e( 'Log in to subscribe', 'extrachill-blog' ); ?></a>
+			<a class="button-1 button-medium entity-pillar-subscription-button" href="<?php echo esc_url( wp_login_url( get_term_link( $term ) ) ); ?>"><?php esc_html_e( 'Log in to subscribe', 'extrachill-blog' ); ?></a>
 		</section>
 		<?php
 		return;
@@ -451,7 +481,7 @@ function extrachill_blog_render_artist_subscription_control() {
 		<h2 id="artist-pillar-subscription-title"><?php esc_html_e( 'Get artist updates', 'extrachill-blog' ); ?></h2>
 		<p><?php esc_html_e( 'Subscribe to private Extra Chill notifications for new editorial coverage of this artist.', 'extrachill-blog' ); ?></p>
 		<button
-			class="entity-pillar-subscription-button"
+			class="button-1 button-medium entity-pillar-subscription-button"
 			type="button"
 			aria-pressed="false"
 			disabled

--- a/inc/archive/festival-subscriptions.php
+++ b/inc/archive/festival-subscriptions.php
@@ -45,7 +45,7 @@ function extrachill_blog_render_festival_subscription_control() {
 		<section class="entity-pillar-subscription" aria-labelledby="festival-pillar-subscription-title">
 			<h2 id="festival-pillar-subscription-title"><?php esc_html_e( 'Get festival updates', 'extrachill-blog' ); ?></h2>
 			<p><?php esc_html_e( 'Log in to subscribe to private Extra Chill notifications for this festival.', 'extrachill-blog' ); ?></p>
-			<a class="entity-pillar-subscription-button" href="<?php echo esc_url( wp_login_url( get_term_link( $term ) ) ); ?>"><?php esc_html_e( 'Log in to subscribe', 'extrachill-blog' ); ?></a>
+			<a class="button-1 button-medium entity-pillar-subscription-button" href="<?php echo esc_url( wp_login_url( get_term_link( $term ) ) ); ?>"><?php esc_html_e( 'Log in to subscribe', 'extrachill-blog' ); ?></a>
 		</section>
 		<?php
 		return;
@@ -57,7 +57,7 @@ function extrachill_blog_render_festival_subscription_control() {
 		<h2 id="festival-pillar-subscription-title"><?php esc_html_e( 'Get festival updates', 'extrachill-blog' ); ?></h2>
 		<p><?php esc_html_e( 'Subscribe to private Extra Chill notifications for new editorial coverage of this festival.', 'extrachill-blog' ); ?></p>
 		<button
-			class="entity-pillar-subscription-button"
+			class="button-1 button-medium entity-pillar-subscription-button"
 			type="button"
 			aria-pressed="false"
 			disabled

--- a/tests/artist-activity.php
+++ b/tests/artist-activity.php
@@ -7,6 +7,8 @@
 
 define( 'ABSPATH', __DIR__ . '/' );
 
+class WP_Post {}
+
 function add_action() {}
 function add_filter() {}
 function __($text) { return $text; }
@@ -26,11 +28,27 @@ $valid = extrachill_blog_build_artist_activity_item(
 	'New show',
 	'https://events.example.test/show/',
 	'2026-07-14T20:00:00+00:00',
-	'Events'
+	'Events',
+	'July 14, 2026',
+	'Example Venue, 8:00 pm',
+	'upcoming'
 );
 assert_same( '2026-07-14T20:00:00+00:00', $valid['date'], 'Activity items should preserve a normalized chronological date.' );
+assert_same( 'Example Venue, 8:00 pm', $valid['context'], 'Event activity items should retain Events-owned venue and time context.' );
+assert_same( 'upcoming', $valid['timing'], 'Event activity items should retain Events-owned timing context.' );
 assert_same( null, extrachill_blog_build_artist_activity_item( '', 'https://example.test/', '2026-07-14', 'Events' ), 'Items without a title must be omitted.' );
 assert_same( null, extrachill_blog_build_artist_activity_item( 'Missing date', 'https://example.test/', '', 'Events' ), 'Items without a date must be omitted.' );
+
+function bbp_get_topic_permalink( $topic_id ) { return 'https://community.example.test/t/canonical-topic-' . $topic_id; }
+
+$topic = new WP_Post();
+$topic->ID = 42;
+assert_same( 'https://community.example.test/t/canonical-topic-42', extrachill_blog_get_artist_community_topic_permalink( $topic ), 'Community activity must use the canonical bbPress topic permalink.' );
+
+$artist_pillar_source         = file_get_contents( dirname( __DIR__ ) . '/inc/archive/artist-pillar.php' );
+$festival_subscriptions_source = file_get_contents( dirname( __DIR__ ) . '/inc/archive/festival-subscriptions.php' );
+assert_same( 2, substr_count( $artist_pillar_source, 'class="button-1 button-medium entity-pillar-subscription-button"' ), 'Artist subscription controls should use theme button classes.' );
+assert_same( 2, substr_count( $festival_subscriptions_source, 'class="button-1 button-medium entity-pillar-subscription-button"' ), 'Festival subscription controls should use theme button classes.' );
 
 $sorted = extrachill_blog_sort_artist_activity(
 	array(


### PR DESCRIPTION
## Summary
- retain Events-owned venue, time, and upcoming/past context in compact artist timeline rows without adding storage or inferring locations
- use canonical bbPress Community topic permalinks and theme button classes for artist and festival subscription controls
- add focused coverage for event context, canonical permalinks, and subscription button classes

## Verification
- `php -l inc/archive/artist-pillar.php`
- `php -l inc/archive/festival-subscriptions.php`
- `php -l tests/artist-activity.php`
- `php tests/artist-activity.php`
- `php tests/festival-subscriptions.php`
- `php tests/homepage-event-markets.php`
- `vendor/bin/phpcs --standard=WordPress inc/archive/artist-pillar.php inc/archive/festival-subscriptions.php`

Closes #55
Closes #56
Closes #57