### PR TITLE
feat: add artist event relationship badges

### DIFF
--- a/assets/css/entity-pillar.css
+++ b/assets/css/entity-pillar.css
@@ -144,6 +144,11 @@
 	font-size: var(--font-size-sm);
 }
 
+.entity-pillar-activity-badges {
+	margin: var(--spacing-sm) 0 0;
+	gap: var(--spacing-xs);
+}
+
 .entity-pillar-newsletter {
 	max-width: var(--content-width);
 	margin: var(--spacing-xl) auto;

--- a/inc/archive/artist-pillar.php
+++ b/inc/archive/artist-pillar.php
@@ -214,7 +214,8 @@ function extrachill_blog_get_artist_events_activity( $term ) {
 			__( 'Events', 'extrachill-blog' ),
 			isset( $event['date_display'] ) ? $event['date_display'] : '',
 			implode( ', ', $event_context ),
-			isset( $event['timing'] ) ? $event['timing'] : ''
+			isset( $event['timing'] ) ? $event['timing'] : '',
+			isset( $event['relationships'] ) ? $event['relationships'] : array()
 		);
 	}
 
@@ -347,24 +348,88 @@ function extrachill_blog_get_artist_platform_activity( $term ) {
  * @param string $date_display Source-formatted date, when available.
  * @param string $context      Source-owned venue and time context, when available.
  * @param string $timing       Source-owned upcoming or past timing, when available.
+ * @param array  $relationships Events-owned venue, location, and festival relationships.
  * @return array|null Activity item.
  */
-function extrachill_blog_build_artist_activity_item( $title, $url, $date, $source, $date_display = '', $context = '', $timing = '' ) {
+function extrachill_blog_build_artist_activity_item( $title, $url, $date, $source, $date_display = '', $context = '', $timing = '', $relationships = array() ) {
 	$timestamp = strtotime( $date );
 	if ( '' === $title || '' === $url || ! $timestamp ) {
 		return null;
 	}
 
 	return array(
-		'title'        => (string) $title,
-		'url'          => (string) $url,
-		'date'         => gmdate( 'c', $timestamp ),
-		'date_display' => '' !== $date_display ? (string) $date_display : wp_date( get_option( 'date_format' ), $timestamp ),
-		'source'       => (string) $source,
-		'context'      => (string) $context,
-		'timing'       => (string) $timing,
-		'timestamp'    => $timestamp,
+		'title'         => (string) $title,
+		'url'           => (string) $url,
+		'date'          => gmdate( 'c', $timestamp ),
+		'date_display'  => '' !== $date_display ? (string) $date_display : wp_date( get_option( 'date_format' ), $timestamp ),
+		'source'        => (string) $source,
+		'context'       => (string) $context,
+		'timing'        => (string) $timing,
+		'relationships' => is_array( $relationships ) ? $relationships : array(),
+		'timestamp'     => $timestamp,
 	);
+}
+
+/**
+ * Return renderable taxonomy badges from Events-owned relationship objects.
+ *
+ * @param array $relationships Event relationship data.
+ * @return array[] Badge data.
+ */
+function extrachill_blog_get_artist_activity_badges( $relationships ) {
+	if ( ! is_array( $relationships ) ) {
+		return array();
+	}
+
+	$badges = array();
+	foreach (
+		array(
+			'venue'    => 'venue-badge',
+			'location' => 'location-badge',
+			'festival' => 'festival-badge',
+		) as $relationship_type => $badge_class
+	) {
+		$relationship = $relationships[ $relationship_type ] ?? null;
+		if ( ! is_array( $relationship ) || empty( $relationship['name'] ) || empty( $relationship['url'] ) ) {
+			continue;
+		}
+
+		$label   = 'location' === $relationship_type && ! empty( $relationship['display'] )
+			? $relationship['display']
+			: $relationship['name'];
+		$classes = array( 'taxonomy-badge', $badge_class );
+		if ( ! empty( $relationship['slug'] ) ) {
+			$classes[] = $relationship_type . '-' . sanitize_html_class( $relationship['slug'] );
+		}
+
+		$badges[] = array(
+			'label' => (string) $label,
+			'url'   => (string) $relationship['url'],
+			'class' => implode( ' ', $classes ),
+		);
+	}
+
+	return $badges;
+}
+
+/**
+ * Render Events-owned taxonomy badges for an activity row.
+ *
+ * @param array $relationships Event relationship data.
+ * @return void
+ */
+function extrachill_blog_render_artist_activity_badges( $relationships ) {
+	$badges = extrachill_blog_get_artist_activity_badges( $relationships );
+	if ( empty( $badges ) ) {
+		return;
+	}
+	?>
+	<div class="taxonomy-badges entity-pillar-activity-badges">
+		<?php foreach ( $badges as $badge ) : ?>
+			<a href="<?php echo esc_url( $badge['url'] ); ?>" class="<?php echo esc_attr( $badge['class'] ); ?>"><?php echo esc_html( $badge['label'] ); ?></a>
+		<?php endforeach; ?>
+	</div>
+	<?php
 }
 
 /**
@@ -416,6 +481,7 @@ function extrachill_blog_render_artist_activity() {
 						<?php if ( ! empty( $item['context'] ) ) : ?>
 							<span class="entity-pillar-activity-context"><?php echo esc_html( $item['context'] ); ?></span>
 						<?php endif; ?>
+						<?php extrachill_blog_render_artist_activity_badges( $item['relationships'] ?? array() ); ?>
 					</div>
 				</li>
 			<?php endforeach; ?>

--- a/tests/artist-activity.php
+++ b/tests/artist-activity.php
@@ -14,11 +14,22 @@ function add_filter() {}
 function __($text) { return $text; }
 function get_option() { return 'F j, Y'; }
 function wp_date( $format, $timestamp ) { return gmdate( $format, $timestamp ); }
+function sanitize_html_class( $class ) { return preg_replace( '/[^A-Za-z0-9_-]/', '-', $class ); }
+function esc_attr( $text ) { return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' ); }
+function esc_html( $text ) { return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' ); }
+function esc_url( $url ) { return htmlspecialchars( $url, ENT_QUOTES, 'UTF-8' ); }
 
 require_once dirname( __DIR__ ) . '/inc/archive/artist-pillar.php';
 
 function assert_same( $expected, $actual, $message ) {
 	if ( $expected !== $actual ) {
+		fwrite( STDERR, $message . "\n" );
+		exit( 1 );
+	}
+}
+
+function assert_true( $actual, $message ) {
+	if ( ! $actual ) {
 		fwrite( STDERR, $message . "\n" );
 		exit( 1 );
 	}
@@ -38,6 +49,37 @@ assert_same( 'Example Venue, 8:00 pm', $valid['context'], 'Event activity items 
 assert_same( 'upcoming', $valid['timing'], 'Event activity items should retain Events-owned timing context.' );
 assert_same( null, extrachill_blog_build_artist_activity_item( '', 'https://example.test/', '2026-07-14', 'Events' ), 'Items without a title must be omitted.' );
 assert_same( null, extrachill_blog_build_artist_activity_item( 'Missing date', 'https://example.test/', '', 'Events' ), 'Items without a date must be omitted.' );
+
+$relationships = array(
+	'venue'    => array( 'name' => 'The <Venue>', 'slug' => 'the-venue', 'url' => 'https://events.example.test/venue/the-venue?label="unsafe"' ),
+	'location' => array( 'name' => 'Charleston', 'slug' => 'charleston', 'url' => 'https://events.example.test/location/charleston', 'display' => 'Charleston & Coast' ),
+	'festival' => array( 'name' => 'Test Fest', 'slug' => 'test-fest', 'url' => 'https://events.example.test/festival/test-fest' ),
+);
+$event = extrachill_blog_build_artist_activity_item( 'Event', 'https://events.example.test/event', '2026-07-14', 'Events', '', '', '', $relationships );
+assert_same( $relationships, $event['relationships'], 'Events relationship objects must remain source-owned activity data.' );
+$badges = extrachill_blog_get_artist_activity_badges( $event['relationships'] );
+assert_same( 3, count( $badges ), 'Venue, location, and festival relationships should each render a badge.' );
+assert_same( 'The <Venue>', $badges[0]['label'], 'Venue badge labels should preserve source data for escaped rendering.' );
+assert_same( 'Charleston & Coast', $badges[1]['label'], 'Location display labels should take precedence when Events provides one.' );
+assert_same( 'taxonomy-badge festival-badge festival-test-fest', $badges[2]['class'], 'Festival badges should use the established taxonomy classes.' );
+ob_start();
+extrachill_blog_render_artist_activity_badges( $relationships );
+$badge_markup = ob_get_clean();
+assert_true( false !== strpos( $badge_markup, 'The &lt;Venue&gt;' ), 'Badge labels must be HTML escaped.' );
+assert_true( false !== strpos( $badge_markup, 'label=&quot;unsafe&quot;' ), 'Badge URLs must be attribute escaped.' );
+assert_true( false !== strpos( $badge_markup, 'class="taxonomy-badge venue-badge venue-the-venue"' ), 'Badge classes must be attribute escaped.' );
+
+$partial_badges = extrachill_blog_get_artist_activity_badges(
+	array(
+		'venue'    => null,
+		'location' => array( 'name' => 'Austin', 'url' => 'https://events.example.test/location/austin' ),
+		'festival' => array( 'name' => 'No Link Fest', 'slug' => 'no-link-fest' ),
+	)
+);
+assert_same( 1, count( $partial_badges ), 'Null and incomplete relationships must be omitted.' );
+assert_same( 'taxonomy-badge location-badge', $partial_badges[0]['class'], 'A relationship without a slug must retain its established base class.' );
+assert_same( array(), extrachill_blog_get_artist_activity_badges( array( 'venue' => 'invalid' ) ), 'Malformed relationship data must be omitted.' );
+assert_same( array(), extrachill_blog_build_artist_activity_item( 'Coverage', 'https://example.test/coverage', '2026-07-14', 'Editorial coverage' )['relationships'], 'Non-event activity rows must not gain relationship badges.' );
 
 function bbp_get_topic_permalink( $topic_id ) { return 'https://community.example.test/t/canonical-topic-' . $topic_id; }
 


### PR DESCRIPTION
## Summary
- Preserve canonical Events venue, location, and festival relationships on artist activity rows.
- Render compact linked taxonomy badges using existing theme variants without synthesizing URLs.
- Cover complete, partial, malformed, escaped, and non-event relationship data.

## Verification
- `php -l inc/archive/artist-pillar.php`
- `php -l tests/artist-activity.php`
- `php tests/artist-activity.php`
- `vendor/bin/phpcs --standard=WordPress inc/archive/artist-pillar.php`
- `git diff --check`