### PR TITLE
feat: make the homepage a personalized network hub

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -17,6 +17,18 @@
     font-family: var(--font-family-heading);
 }
 
+.hero-profile-link {
+    color: inherit;
+    text-decoration-color: var(--accent);
+    text-decoration-thickness: 2px;
+    text-underline-offset: 0.15em;
+}
+
+.hero-profile-link:hover,
+.hero-profile-link:focus {
+    color: var(--accent);
+}
+
 #hero-section h3 {
     font-size: var(--font-size-xl);
     margin-bottom: var(--spacing-xl);

--- a/assets/css/power.css
+++ b/assets/css/power.css
@@ -1,5 +1,5 @@
 /**
- * Styles for the /power manifesto page.
+ * Styles for the /power network explorer.
  *
  * Built entirely on the live Extra Chill design tokens (the `--*` CSS custom
  * properties from the theme's root.css). Because EC dark mode flips those
@@ -70,49 +70,6 @@
 	color: var(--muted-text);
 }
 
-/* ---- Pillars ---- */
-
-.power-pillars {
-	display: grid;
-	grid-template-columns: 1fr;
-	gap: var(--spacing-md);
-}
-
-@media (min-width: 700px) {
-	.power-pillars {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-	}
-}
-
-.power-pillar {
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	gap: var(--spacing-md);
-	padding: var(--spacing-lg);
-	background: var(--card-background);
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius-xl);
-}
-
-.power-pillar__title {
-	margin: 0;
-	font-family: var(--font-family-heading);
-	font-size: var(--font-size-xl);
-	color: var(--text-color);
-}
-
-.power-pillar__statement {
-	margin: 0;
-	font-size: var(--font-size-body);
-	color: var(--text-color);
-	flex: 1 1 auto;
-}
-
-.power-pillar__cta {
-	margin-top: auto;
-}
-
 /* ---- Network map ---- */
 
 .power-network-map {
@@ -180,64 +137,27 @@
 	color: var(--link-color);
 }
 
-/* ---- Artist conversion section ---- */
+/* ---- Independence note ---- */
 
-.power-artists {
-	padding: var(--spacing-xl) var(--spacing-lg);
-	background: var(--card-background);
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius-xl);
-	margin: var(--spacing-xl) var(--spacing-md);
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	gap: var(--spacing-md);
-}
-
-.power-artists__title {
-	margin: 0;
-	font-family: var(--font-family-heading);
-	font-size: var(--font-size-2xl);
-	color: var(--text-color);
-}
-
-.power-artists__intro {
-	margin: 0;
-	font-size: var(--font-size-body);
-	color: var(--text-color);
-}
-
-.power-artists__list {
-	margin: 0;
-	padding-left: var(--spacing-lg);
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing-sm);
-	font-size: var(--font-size-body);
-	color: var(--text-color);
-}
-
-/* ---- Closing ---- */
-
-.power-closing {
+.power-note {
 	text-align: center;
-	padding: var(--spacing-xl) var(--spacing-md);
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: var(--spacing-md);
+	margin: var(--spacing-xl) var(--spacing-md);
+	padding: var(--spacing-xl);
+	background: var(--card-background);
+	border-left: 5px solid var(--accent);
+	border-radius: var(--border-radius-xl);
 }
 
-.power-closing__title {
-	margin: 0;
+.power-note__title {
+	margin: 0 0 var(--spacing-sm);
 	font-family: var(--font-family-heading);
 	font-size: var(--font-size-2xl);
 	color: var(--text-color);
 }
 
-.power-closing__text {
-	margin: 0;
-	max-width: 36rem;
+.power-note p {
+	margin: 0 auto;
+	max-width: 40rem;
 	font-size: var(--font-size-body);
 	color: var(--text-color);
 }

--- a/inc/home/homepage-hooks.php
+++ b/inc/home/homepage-hooks.php
@@ -14,6 +14,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Tag a cross-site destination for the existing network bridge analytics.
+ *
+ * @param string $url      Destination URL.
+ * @param string $site_key Canonical destination site key.
+ * @param string $source   Analytics source placement.
+ * @return string
+ */
+function extrachill_blog_bridge_url( $url, $site_key, $source = 'homepage' ) {
+	return function_exists( 'extrachill_network_bridge_tag_url' )
+		? extrachill_network_bridge_tag_url( $url, $site_key, $source )
+		: $url;
+}
+
+/**
  * Schedule the Recently Shipped warmer without performing a frontend fetch.
  */
 function extrachill_blog_schedule_recently_shipped_refresh() {

--- a/inc/home/templates/hero.php
+++ b/inc/home/templates/hero.php
@@ -10,10 +10,17 @@
  * @since 0.1.0
  */
 
-$username = '';
+$username    = '';
+$profile_url = '';
 if ( is_user_logged_in() ) {
 	$user     = wp_get_current_user();
 	$username = $user->user_nicename;
+	if ( function_exists( 'extrachill_get_user_profile_url' ) ) {
+		$profile_url = extrachill_get_user_profile_url( $user->ID, $user->user_email );
+		if ( $profile_url ) {
+			$profile_url = extrachill_blog_bridge_url( $profile_url, 'community' );
+		}
+	}
 }
 
 $hero_stats = extrachill_blog_get_hero_stats();
@@ -28,17 +35,24 @@ $hero_stat_labels = array(
 $events_url    = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'events' ) : 'https://events.extrachill.com';
 $community_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : 'https://community.extrachill.com';
 $artist_url    = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'artist' ) : 'https://artist.extrachill.com';
+$events_url    = extrachill_blog_bridge_url( $events_url, 'events' );
+$community_url = extrachill_blog_bridge_url( $community_url, 'community' );
+$artist_url    = extrachill_blog_bridge_url( $artist_url, 'artist' );
 ?>
 <div class="full-width-breakout ec-edge-shell">
 <section id="hero-section">
 	<h2>
 		<?php
 		if ( $username ) {
-			printf(
-				/* translators: %s: user display name */
-				esc_html__( 'Welcome back, %s', 'extrachill-blog' ),
-				esc_html( $username )
-			);
+			esc_html_e( 'Welcome back,', 'extrachill-blog' );
+			echo ' ';
+			if ( $profile_url ) {
+				?>
+				<a class="hero-profile-link ec-cross-site-link" href="<?php echo esc_url( $profile_url ); ?>"><?php echo esc_html( $username ); ?></a>
+				<?php
+			} else {
+				echo esc_html( $username );
+			}
 		} else {
 			esc_html_e( 'Join the Online Music Scene', 'extrachill-blog' );
 		}
@@ -66,17 +80,17 @@ $artist_url    = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'artist
 
 	<div class="hero-buttons-container">
 		<a href="<?php echo esc_url( $events_url ); ?>"
-			class="button-1 button-medium">
+			class="button-1 button-medium ec-cross-site-link">
 			<?php esc_html_e( 'Live Music Calendar', 'extrachill-blog' ); ?>
 		</a>
 
 		<a href="<?php echo esc_url( $community_url ); ?>"
-			class="button-2 button-medium">
+			class="button-2 button-medium ec-cross-site-link">
 			<?php esc_html_e( 'Community', 'extrachill-blog' ); ?>
 		</a>
 
 		<a href="<?php echo esc_url( $artist_url ); ?>"
-			class="button-3 button-medium">
+			class="button-3 button-medium ec-cross-site-link">
 			<?php esc_html_e( 'Artist Platform', 'extrachill-blog' ); ?>
 		</a>
 	</div>

--- a/inc/home/templates/section-artist-platform.php
+++ b/inc/home/templates/section-artist-platform.php
@@ -12,6 +12,10 @@ $is_logged_in       = is_user_logged_in();
 $user_artist_ids    = array();
 $can_create_artists = false;
 $artist_site_url    = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'artist' ) : 'https://artist.extrachill.com';
+$manage_url         = extrachill_blog_bridge_url( $artist_site_url . '/manage-artist/', 'artist' );
+$create_url         = extrachill_blog_bridge_url( $artist_site_url . '/create-artist/', 'artist' );
+$join_url           = extrachill_blog_bridge_url( 'https://extrachill.link/join', 'artist' );
+$browse_url         = extrachill_blog_bridge_url( $artist_site_url . '/artists/', 'artist' );
 
 if ( $is_logged_in ) {
 	if ( function_exists( 'ec_get_artists_for_user' ) ) {
@@ -29,12 +33,12 @@ if ( $is_logged_in ) {
 	</p>
 	<div class="home-network-card-cta home-network-card-cta-row">
 		<?php if ( $is_logged_in && ! empty( $user_artist_ids ) ) : ?>
-			<a href="<?php echo esc_url( $artist_site_url . '/manage-artist/' ); ?>" class="button-1 button-medium">Manage Artists</a>
+			<a href="<?php echo esc_url( $manage_url ); ?>" class="button-1 button-medium ec-cross-site-link">Manage Artists</a>
 		<?php elseif ( $is_logged_in && $can_create_artists ) : ?>
-			<a href="<?php echo esc_url( $artist_site_url . '/create-artist/' ); ?>" class="button-1 button-medium">Create Artist Profile</a>
+			<a href="<?php echo esc_url( $create_url ); ?>" class="button-1 button-medium ec-cross-site-link">Create Artist Profile</a>
 		<?php else : ?>
-			<a href="https://extrachill.link/join" class="button-1 button-medium" target="_blank" rel="noopener">Join the Platform</a>
+			<a href="<?php echo esc_url( $join_url ); ?>" class="button-1 button-medium ec-cross-site-link" target="_blank" rel="noopener">Join the Platform</a>
 		<?php endif; ?>
-		<a href="<?php echo esc_url( $artist_site_url . '/artists/' ); ?>" class="button-3 button-medium">Browse Artists</a>
+		<a href="<?php echo esc_url( $browse_url ); ?>" class="button-3 button-medium ec-cross-site-link">Browse Artists</a>
 	</div>
 </div>

--- a/inc/home/templates/section-community.php
+++ b/inc/home/templates/section-community.php
@@ -15,6 +15,9 @@ $profile_url  = '';
 
 if ( $is_logged_in && function_exists( 'extrachill_get_user_profile_url' ) ) {
 	$profile_url = extrachill_get_user_profile_url( get_current_user_id() );
+	if ( $profile_url ) {
+		$profile_url = extrachill_blog_bridge_url( $profile_url, 'community' );
+	}
 }
 
 $community_activity = function_exists( 'extrachill_get_community_activity_items' )
@@ -29,7 +32,7 @@ $community_activity = function_exists( 'extrachill_get_community_activity_items'
 	<?php if ( ! empty( $community_activity ) ) : ?>
 		<div class="home-community-activity">
 			<?php foreach ( $community_activity as $activity ) : ?>
-				<a class="home-community-activity-item" href="<?php echo esc_url( $activity['topic_url'] ); ?>">
+				<a class="home-community-activity-item ec-cross-site-link" href="<?php echo esc_url( extrachill_blog_bridge_url( $activity['topic_url'], 'community' ) ); ?>">
 					<span class="home-community-activity-title"><?php echo esc_html( $activity['topic_title'] ); ?></span>
 					<span class="home-community-activity-meta">
 						<?php
@@ -47,10 +50,10 @@ $community_activity = function_exists( 'extrachill_get_community_activity_items'
 	<?php endif; ?>
 	<div class="home-network-card-cta home-network-card-cta-row">
 		<?php if ( $is_logged_in && $profile_url ) : ?>
-			<a href="<?php echo esc_url( $profile_url ); ?>" class="button-2 button-medium"><?php esc_html_e( 'Your Profile', 'extrachill-blog' ); ?></a>
+			<a href="<?php echo esc_url( $profile_url ); ?>" class="button-2 button-medium ec-cross-site-link"><?php esc_html_e( 'Your Profile', 'extrachill-blog' ); ?></a>
 		<?php else : ?>
-			<a href="https://community.extrachill.com" class="button-2 button-medium"><?php esc_html_e( 'Join the Conversation', 'extrachill-blog' ); ?></a>
+			<a href="<?php echo esc_url( extrachill_blog_bridge_url( 'https://community.extrachill.com', 'community' ) ); ?>" class="button-2 button-medium ec-cross-site-link"><?php esc_html_e( 'Join the Conversation', 'extrachill-blog' ); ?></a>
 		<?php endif; ?>
-		<a href="https://community.extrachill.com/recent" class="button-3 button-medium"><?php esc_html_e( 'Recent Activity', 'extrachill-blog' ); ?></a>
+		<a href="<?php echo esc_url( extrachill_blog_bridge_url( 'https://community.extrachill.com/recent', 'community' ) ); ?>" class="button-3 button-medium ec-cross-site-link"><?php esc_html_e( 'Recent Activity', 'extrachill-blog' ); ?></a>
 	</div>
 </div>

--- a/inc/home/templates/section-docs.php
+++ b/inc/home/templates/section-docs.php
@@ -13,6 +13,6 @@
 		Everything you need to know about the Extra Chill ecosystem. Comprehensive guides for artists and fans to get the most out of our platform.
 	</p>
 	<div class="home-network-card-cta">
-		<a href="https://docs.extrachill.com" class="button-3 button-medium">Explore the Docs</a>
+		<a href="<?php echo esc_url( extrachill_blog_bridge_url( 'https://docs.extrachill.com', 'docs' ) ); ?>" class="button-3 button-medium ec-cross-site-link">Explore the Docs</a>
 	</div>
 </div>

--- a/inc/home/templates/section-events.php
+++ b/inc/home/templates/section-events.php
@@ -10,6 +10,8 @@
  */
 
 $events_site_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'events' ) : 'https://events.extrachill.com';
+$browse_url      = extrachill_blog_bridge_url( $events_site_url, 'events' );
+$submit_url      = extrachill_blog_bridge_url( trailingslashit( $events_site_url ) . 'submit', 'events' );
 ?>
 <div class="home-network-card" aria-labelledby="events-header">
 	<h2 class="home-network-card-header" id="events-header"><?php esc_html_e( 'Events Calendar', 'extrachill-blog' ); ?></h2>
@@ -17,7 +19,7 @@ $events_site_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'even
 		<?php esc_html_e( 'Discover concerts, festivals, and music events in your city — free to browse, no login wall. DIY artists can submit their own events to share with the Extra Chill network.', 'extrachill-blog' ); ?>
 	</p>
 	<div class="home-network-card-cta home-network-card-cta-row">
-		<a href="<?php echo esc_url( $events_site_url ); ?>" class="button-2 button-medium"><?php esc_html_e( 'Browse Events', 'extrachill-blog' ); ?></a>
-		<a href="<?php echo esc_url( trailingslashit( $events_site_url ) . 'submit' ); ?>" class="button-3 button-medium"><?php esc_html_e( 'Submit an Event', 'extrachill-blog' ); ?></a>
+		<a href="<?php echo esc_url( $browse_url ); ?>" class="button-2 button-medium ec-cross-site-link"><?php esc_html_e( 'Browse Events', 'extrachill-blog' ); ?></a>
+		<a href="<?php echo esc_url( $submit_url ); ?>" class="button-3 button-medium ec-cross-site-link"><?php esc_html_e( 'Submit an Event', 'extrachill-blog' ); ?></a>
 	</div>
 </div>

--- a/inc/power/power-page.php
+++ b/inc/power/power-page.php
@@ -1,12 +1,11 @@
 <?php
 /**
- * The /power network manifesto landing page.
+ * The /power network explorer landing page.
  *
- * The /power surface is the network MANIFESTO + router: it tells outsiders
+ * The /power surface is the network router: it shows outsiders
  * Extra Chill is a whole independent-music NETWORK (events, community, wire,
- * artist platform, publication), not just a blog. It is manifesto-first,
- * routing-second — it LINKS to the live surfaces, it does not embed cross-blog
- * functional blocks.
+ * artist platform, publication), not just a blog. It leads with links to the
+ * live surfaces rather than making visitors read a manifesto first.
  *
  * Approach (server-rendered page):
  *  - /power is a standard published WP Page at the (confirmed-free) slug
@@ -14,7 +13,7 @@
  *    admin_init — the same provisioning convention the artist platform uses for
  *    /create-artist et al. The page renders through the theme's normal loop +
  *    inc/single/single-page.php (which calls the_content()).
- *  - The manifesto + network map are rendered SERVER-SIDE via a `the_content`
+ *  - The network explorer is rendered SERVER-SIDE via a `the_content`
  *    filter (inc/power/power-template.php), NOT seeded as Gutenberg block
  *    markup. This is deliberate and matches every other Extra Chill surface
  *    (homepage section templates, network-bridge, etc.): plain semantic HTML
@@ -41,8 +40,6 @@
  *    re-aim is artist-platform#76, intentionally not touched here).
  *  - Cards deep-link OUT to the subsites; the page embeds no cross-blog
  *    functional blocks.
- *  - The artist conversion section carries an #artists anchor so the future
- *    footer re-aim can target it directly.
  *
  * @package ExtraChillBlog
  * @since 0.6.0
@@ -55,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once __DIR__ . '/power-template.php';
 
 /**
- * Slug for the manifesto page.
+ * Slug for the network explorer page.
  */
 const EXTRACHILL_BLOG_POWER_SLUG = 'power';
 
@@ -63,7 +60,7 @@ const EXTRACHILL_BLOG_POWER_SLUG = 'power';
  * Ensure the published /power page exists, creating it if absent.
  *
  * The page is a lightweight shell: its stored content is a single sentinel
- * paragraph. The manifesto + network map are injected at render time by the
+ * paragraph. The network explorer is injected at render time by the
  * the_content filter in power-template.php, so the live design tokens (and
  * therefore dark mode) always apply and the proof numbers are never frozen
  * into post_content.
@@ -107,14 +104,14 @@ function extrachill_blog_maybe_create_power_page() {
 add_action( 'admin_init', 'extrachill_blog_maybe_create_power_page' );
 
 /**
- * Replace the /power page content with the server-rendered manifesto.
+ * Replace the /power page content with the server-rendered network explorer.
  *
  * Runs only in the main query on the /power page so block themes, feeds, and
- * other contexts are untouched. Hides the page title (the manifesto supplies
+ * other contexts are untouched. Hides the page title (the explorer supplies
  * its own hero H1).
  *
  * @param string $content Original post content.
- * @return string Manifesto HTML on /power, original content otherwise.
+ * @return string Network explorer HTML on /power, original content otherwise.
  */
 function extrachill_blog_render_power_content( $content ) {
 	if ( ! is_page( EXTRACHILL_BLOG_POWER_SLUG ) || ! is_main_query() || ! in_the_loop() ) {

--- a/inc/power/power-template.php
+++ b/inc/power/power-template.php
@@ -1,17 +1,14 @@
 <?php
 /**
- * Server-rendered markup for the /power manifesto page.
+ * Server-rendered markup for the /power network explorer.
  *
  * Plain semantic HTML styled by assets/css/power.css using the LIVE design
  * tokens, so the page renders correctly in both light and dark mode (EC dark
  * mode flips the `--*` CSS variables via root.css @media prefers-color-scheme).
  *
- * Sections, in order:
- *   1. HERO — one-line reframe + one low-commitment CTA.
- *   2. PILLARS — four values units (heading + statement + CTA).
- *   3. NETWORK MAP — surface cards with LIVE proof numbers + deep links.
- *   4. ARTIST SECTION (#artists) — focused conversion slice for artists.
- *   5. CLOSING — repeated low-commitment CTA.
+ * Sections, in order: a concise hero, the live network map, and one short
+ * independence statement. The page routes visitors into the working network
+ * instead of making them read a manifesto before they can explore it.
  *
  * All NetworkStats reads are guarded; unavailable metrics degrade to
  * label-only cards. Subsite URLs resolve via ec_get_site_url() with hardcoded
@@ -128,27 +125,6 @@ function extrachill_blog_power_proof_line( array $stats, array $fragments ) {
 }
 
 /**
- * Render a single manifesto pillar (heading + statement + CTA).
- *
- * @param string $heading   Pillar headline.
- * @param string $statement Short statement.
- * @param string $cta_label CTA label.
- * @param string $cta_url   CTA URL.
- * @return string Pillar HTML.
- */
-function extrachill_blog_power_pillar( $heading, $statement, $cta_label, $cta_url ) {
-	ob_start();
-	?>
-	<div class="power-pillar">
-		<h3 class="power-pillar__title"><?php echo esc_html( $heading ); ?></h3>
-		<p class="power-pillar__statement"><?php echo esc_html( $statement ); ?></p>
-		<a class="button-1 button-medium power-pillar__cta" href="<?php echo esc_url( $cta_url ); ?>"><?php echo esc_html( $cta_label ); ?></a>
-	</div>
-	<?php
-	return trim( ob_get_clean() );
-}
-
-/**
  * Render the network-map surface cards with live proof numbers.
  *
  * @return string Network-map HTML.
@@ -158,11 +134,12 @@ function extrachill_blog_power_network_map() {
 
 	$cards = array(
 		array(
-			'title' => __( 'Live Music Calendar', 'extrachill-blog' ),
-			'desc'  => __( 'Concerts everywhere — big cities and small, big artists and small — free to browse, no login wall.', 'extrachill-blog' ),
-			'url'   => extrachill_blog_power_site_url( 'events', 'https://events.extrachill.com' ),
-			'cta'   => __( 'Browse the calendar', 'extrachill-blog' ),
-			'proof' => extrachill_blog_power_proof_line(
+			'title'    => __( 'Live Music Calendar', 'extrachill-blog' ),
+			'desc'     => __( 'Concerts everywhere — big cities and small, big artists and small — free to browse, no login wall.', 'extrachill-blog' ),
+			'url'      => extrachill_blog_power_site_url( 'events', 'https://events.extrachill.com' ),
+			'site_key' => 'events',
+			'cta'      => __( 'Browse the calendar', 'extrachill-blog' ),
+			'proof'    => extrachill_blog_power_proof_line(
 				$stats,
 				array(
 					array(
@@ -179,11 +156,12 @@ function extrachill_blog_power_network_map() {
 			),
 		),
 		array(
-			'title' => __( 'The Community', 'extrachill-blog' ),
-			'desc'  => __( 'Forums for musicians, fans, and industry folks — the online music scene, in conversation.', 'extrachill-blog' ),
-			'url'   => extrachill_blog_power_site_url( 'community', 'https://community.extrachill.com' ),
-			'cta'   => __( 'Join the conversation', 'extrachill-blog' ),
-			'proof' => extrachill_blog_power_proof_line(
+			'title'    => __( 'The Community', 'extrachill-blog' ),
+			'desc'     => __( 'Forums for musicians, fans, and industry folks — the online music scene, in conversation.', 'extrachill-blog' ),
+			'url'      => extrachill_blog_power_site_url( 'community', 'https://community.extrachill.com' ),
+			'site_key' => 'community',
+			'cta'      => __( 'Join the conversation', 'extrachill-blog' ),
+			'proof'    => extrachill_blog_power_proof_line(
 				$stats,
 				array(
 					array(
@@ -200,11 +178,12 @@ function extrachill_blog_power_network_map() {
 			),
 		),
 		array(
-			'title' => __( 'Festival Wire', 'extrachill-blog' ),
-			'desc'  => __( 'Timely, no-nonsense coverage of festival news and lineups as it breaks.', 'extrachill-blog' ),
-			'url'   => extrachill_blog_power_site_url( 'wire', 'https://wire.extrachill.com' ),
-			'cta'   => __( 'Read the Wire', 'extrachill-blog' ),
-			'proof' => extrachill_blog_power_proof_line(
+			'title'    => __( 'Festival Wire', 'extrachill-blog' ),
+			'desc'     => __( 'Timely, no-nonsense coverage of festival news and lineups as it breaks.', 'extrachill-blog' ),
+			'url'      => extrachill_blog_power_site_url( 'wire', 'https://wire.extrachill.com' ),
+			'site_key' => 'wire',
+			'cta'      => __( 'Read the Wire', 'extrachill-blog' ),
+			'proof'    => extrachill_blog_power_proof_line(
 				$stats,
 				array(
 					array(
@@ -216,11 +195,12 @@ function extrachill_blog_power_network_map() {
 			),
 		),
 		array(
-			'title' => __( 'Artist Platform', 'extrachill-blog' ),
-			'desc'  => __( 'Free link pages, subscribers, and analytics for independent artists to run their own corner.', 'extrachill-blog' ),
-			'url'   => extrachill_blog_power_site_url( 'artist', 'https://artist.extrachill.com' ),
-			'cta'   => __( 'Explore the platform', 'extrachill-blog' ),
-			'proof' => extrachill_blog_power_proof_line(
+			'title'    => __( 'Artist Platform', 'extrachill-blog' ),
+			'desc'     => __( 'Free link pages, subscribers, and analytics for independent artists to run their own corner.', 'extrachill-blog' ),
+			'url'      => extrachill_blog_power_site_url( 'artist', 'https://artist.extrachill.com' ),
+			'site_key' => 'artist',
+			'cta'      => __( 'Explore the platform', 'extrachill-blog' ),
+			'proof'    => extrachill_blog_power_proof_line(
 				$stats,
 				array(
 					array(
@@ -232,11 +212,12 @@ function extrachill_blog_power_network_map() {
 			),
 		),
 		array(
-			'title' => __( 'The Publication', 'extrachill-blog' ),
-			'desc'  => __( 'Where it all started in 2011 — independent music journalism, written by people who show up.', 'extrachill-blog' ),
-			'url'   => home_url( '/' ),
-			'cta'   => __( 'Read the blog', 'extrachill-blog' ),
-			'proof' => extrachill_blog_power_proof_line(
+			'title'    => __( 'The Publication', 'extrachill-blog' ),
+			'desc'     => __( 'Where it all started in 2011 — independent music journalism, written by people who show up.', 'extrachill-blog' ),
+			'url'      => home_url( '/' ),
+			'site_key' => '',
+			'cta'      => __( 'Read the blog', 'extrachill-blog' ),
+			'proof'    => extrachill_blog_power_proof_line(
 				$stats,
 				array(
 					array(
@@ -248,11 +229,12 @@ function extrachill_blog_power_network_map() {
 			),
 		),
 		array(
-			'title' => __( 'The Open-Source Platform', 'extrachill-blog' ),
-			'desc'  => __( 'The whole network is open source — and increasingly built and operated by AI agents we direct in plain language, live on the server. Peek under the hood.', 'extrachill-blog' ),
-			'url'   => 'https://github.com/Extra-Chill',
-			'cta'   => __( 'See the code on GitHub', 'extrachill-blog' ),
-			'proof' => '',
+			'title'    => __( 'The Open-Source Platform', 'extrachill-blog' ),
+			'desc'     => __( 'The whole network is open source and built in public. Peek under the hood.', 'extrachill-blog' ),
+			'url'      => 'https://github.com/Extra-Chill',
+			'site_key' => '',
+			'cta'      => __( 'See the code on GitHub', 'extrachill-blog' ),
+			'proof'    => '',
 		),
 	);
 
@@ -260,7 +242,11 @@ function extrachill_blog_power_network_map() {
 	?>
 	<div class="power-network-map">
 		<?php foreach ( $cards as $card ) : ?>
-			<a class="power-network-card" href="<?php echo esc_url( $card['url'] ); ?>">
+			<?php
+			$card_url   = $card['site_key'] ? extrachill_blog_bridge_url( $card['url'], $card['site_key'], 'power' ) : $card['url'];
+			$card_class = $card['site_key'] ? 'power-network-card ec-cross-site-link' : 'power-network-card';
+			?>
+			<a class="<?php echo esc_attr( $card_class ); ?>" href="<?php echo esc_url( $card_url ); ?>">
 				<h3 class="power-network-card__title"><?php echo esc_html( $card['title'] ); ?></h3>
 				<?php if ( ! empty( $card['proof'] ) ) : ?>
 					<p class="power-network-card__proof"><?php echo esc_html( $card['proof'] ); ?></p>
@@ -275,94 +261,30 @@ function extrachill_blog_power_network_map() {
 }
 
 /**
- * Render the full /power manifesto HTML.
+ * Render the full /power network explorer HTML.
  *
  * @return string Manifesto markup.
  */
 function extrachill_blog_power_manifesto_html() {
-	$community_url       = extrachill_blog_power_site_url( 'community', 'https://community.extrachill.com' );
-	$events_url          = extrachill_blog_power_site_url( 'events', 'https://events.extrachill.com' );
-	$artist_url          = extrachill_blog_power_site_url( 'artist', 'https://artist.extrachill.com' );
-	$artist_register_url = trailingslashit( $artist_url ) . 'login/#tab-register';
-
-	$pillars = array(
-		extrachill_blog_power_pillar(
-			__( 'The Power of Independent Music', 'extrachill-blog' ),
-			__( 'Our live music calendar is on a mission: a comprehensive listing of concerts everywhere — big cities and small ones, big artists and small ones alike. Free to browse, no login wall, no algorithm deciding what you see — just a straight answer to "who\'s playing near me?"', 'extrachill-blog' ),
-			__( 'Browse the calendar', 'extrachill-blog' ),
-			$events_url
-		),
-		extrachill_blog_power_pillar(
-			__( 'The Power of Community', 'extrachill-blog' ),
-			__( 'We are not shouting into the void. Musicians, fans, and industry folks meet in the same forums, upvote each other, and build real connections. The scene is a conversation, and everyone has a seat at the table.', 'extrachill-blog' ),
-			__( 'Join the conversation', 'extrachill-blog' ),
-			$community_url
-		),
-		extrachill_blog_power_pillar(
-			__( 'The Power of the Platform', 'extrachill-blog' ),
-			__( 'Every independent artist gets a free home base: a link page at extrachill.link, your own subscribers, and analytics. You own your corner — we just hand you the keys and get out of the way.', 'extrachill-blog' ),
-			__( 'Build your home base', 'extrachill-blog' ),
-			$artist_register_url
-		),
-		extrachill_blog_power_pillar(
-			__( 'The Power of Staying True', 'extrachill-blog' ),
-			__( 'Since 2011, out of a Charleston dorm room. We stand by our core philosophies and never give in to corporate pressure or aggressive monetization. Sustainable, memorable, and built on the spirit of the music.', 'extrachill-blog' ),
-			__( 'Read our story', 'extrachill-blog' ),
-			home_url( '/about/' )
-		),
-	);
-
-	$artist_benefits = array(
-		__( 'A free link page at extrachill.link — your whole presence at one URL.', 'extrachill-blog' ),
-		__( 'Build a subscriber list so you can reach fans directly.', 'extrachill-blog' ),
-		__( 'Get discovered by a community that actually shows up.', 'extrachill-blog' ),
-		__( 'Analytics so you can see what\'s working.', 'extrachill-blog' ),
-	);
-
 	ob_start();
 	?>
 	<div class="power-page">
 
 		<header class="power-hero">
 			<h1 class="power-hero__title"><?php esc_html_e( 'Extra Chill is not a blog. It\'s a whole network.', 'extrachill-blog' ); ?></h1>
-			<p class="power-hero__lede"><?php esc_html_e( 'Most people find us through one article and never realize what\'s underneath: an independent, open-source music network. A live concert calendar, a community of musicians and fans, a festival news wire, and free tools for artists to run their own corner. All grassroots, all independent, no astro-turf.', 'extrachill-blog' ); ?></p>
-			<a class="button-1 button-large power-hero__cta" href="<?php echo esc_url( $community_url ); ?>"><?php esc_html_e( 'Join the community', 'extrachill-blog' ); ?></a>
+			<p class="power-hero__lede"><?php esc_html_e( 'One independent music scene with many doors. Pick the part that feels like home.', 'extrachill-blog' ); ?></p>
 		</header>
 
 		<section class="power-section">
-			<h2 class="power-section__heading"><?php esc_html_e( 'What we stand for', 'extrachill-blog' ); ?></h2>
-			<div class="power-pillars">
-				<?php
-				foreach ( $pillars as $pillar ) {
-					echo $pillar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- built from esc_* helpers in extrachill_blog_power_pillar().
-				}
-				?>
-			</div>
-		</section>
-
-		<section class="power-section">
-			<h2 class="power-section__heading"><?php esc_html_e( 'One network, many doors', 'extrachill-blog' ); ?></h2>
-			<p class="power-section__lede"><?php esc_html_e( 'Every surface below is live and growing. Pick a door.', 'extrachill-blog' ); ?></p>
+			<h2 class="power-section__heading"><?php esc_html_e( 'Pick a door', 'extrachill-blog' ); ?></h2>
 			<?php
 			echo extrachill_blog_power_network_map(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- built from esc_* helpers in extrachill_blog_power_network_map().
 			?>
 		</section>
 
-		<section class="power-artists" id="artists">
-			<h2 class="power-artists__title"><?php esc_html_e( 'Are you an artist? Here\'s your home base.', 'extrachill-blog' ); ?></h2>
-			<p class="power-artists__intro"><?php esc_html_e( 'Extra Chill gives independent artists real tools, free, with no catch:', 'extrachill-blog' ); ?></p>
-			<ul class="power-artists__list">
-				<?php foreach ( $artist_benefits as $benefit ) : ?>
-					<li><?php echo esc_html( $benefit ); ?></li>
-				<?php endforeach; ?>
-			</ul>
-			<a class="button-1 button-large power-artists__cta" href="<?php echo esc_url( $artist_register_url ); ?>"><?php esc_html_e( 'Claim your free artist profile', 'extrachill-blog' ); ?></a>
-		</section>
-
-		<section class="power-closing">
-			<h2 class="power-closing__title"><?php esc_html_e( 'We hope you\'ll stick around.', 'extrachill-blog' ); ?></h2>
-			<p class="power-closing__text"><?php esc_html_e( 'If independent music is your thing, you\'re already home. Pull up a chair in the community.', 'extrachill-blog' ); ?></p>
-			<a class="button-1 button-large power-closing__cta" href="<?php echo esc_url( $community_url ); ?>"><?php esc_html_e( 'Join the community', 'extrachill-blog' ); ?></a>
+		<section class="power-note">
+			<h2 class="power-note__title"><?php esc_html_e( 'Independent since 2011', 'extrachill-blog' ); ?></h2>
+			<p><?php esc_html_e( 'Extra Chill is grassroots, open source, and built for the people who make music scenes matter. No corporate playbook. No algorithm deciding who deserves a voice.', 'extrachill-blog' ); ?></p>
 		</section>
 
 	</div>

--- a/tests/homepage-network-hub.php
+++ b/tests/homepage-network-hub.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Focused tests for homepage bridge URLs and the concise Power explorer.
+ *
+ * Run: php tests/homepage-network-hub.php
+ */
+
+define( 'ABSPATH', __DIR__ );
+define( 'MINUTE_IN_SECONDS', 60 );
+
+function add_action() {}
+function extrachill_network_bridge_tag_url( $url, $site_key, $source ) {
+	return $url . '?' . http_build_query(
+		array(
+			'utm_source'   => $source,
+			'utm_medium'   => 'network_bridge',
+			'utm_campaign' => $site_key,
+		)
+	);
+}
+function __( $text ) {
+	return $text;
+}
+function esc_html_e( $text ) {
+	echo htmlspecialchars( $text, ENT_QUOTES );
+}
+function esc_html( $text ) {
+	return htmlspecialchars( $text, ENT_QUOTES );
+}
+function esc_attr( $text ) {
+	return htmlspecialchars( $text, ENT_QUOTES );
+}
+function esc_url( $url ) {
+	return htmlspecialchars( $url, ENT_QUOTES );
+}
+function home_url( $path = '' ) {
+	return 'https://extrachill.com' . $path;
+}
+function number_format_i18n( $number ) {
+	return number_format( $number );
+}
+function ec_get_network_stats() {
+	return array();
+}
+function ec_get_site_url( $site_key ) {
+	return 'https://' . $site_key . '.extrachill.com';
+}
+
+require dirname( __DIR__ ) . '/inc/home/homepage-hooks.php';
+require dirname( __DIR__ ) . '/inc/power/power-template.php';
+
+$failures = 0;
+function check( $label, $condition ) {
+	global $failures;
+	if ( $condition ) {
+		echo "PASS: $label\n";
+		return;
+	}
+
+	echo "FAIL: $label\n";
+	++$failures;
+}
+
+$homepage_url = extrachill_blog_bridge_url( 'https://community.extrachill.com', 'community' );
+check( 'homepage destination uses existing bridge analytics contract', false !== strpos( $homepage_url, 'utm_source=homepage' ) );
+check( 'homepage destination carries canonical site key', false !== strpos( $homepage_url, 'utm_campaign=community' ) );
+
+$power = extrachill_blog_power_manifesto_html();
+check( 'Power opens with a concise network promise', false !== strpos( $power, 'One independent music scene with many doors.' ) );
+check( 'Power leads visitors to the network doors', false !== strpos( $power, 'Pick a door' ) );
+check( 'Power cards use existing bridge instrumentation class', false !== strpos( $power, 'power-network-card ec-cross-site-link' ) );
+check( 'Power destinations identify the Power placement', false !== strpos( $power, 'utm_source=power' ) );
+check( 'long manifesto pillars are removed', false === strpos( $power, 'What we stand for' ) );
+check( 'duplicated artist conversion section is removed', false === strpos( $power, 'Claim your free artist profile' ) );
+
+if ( $failures > 0 ) {
+	exit( 1 );
+}
+
+echo "All homepage network hub tests passed.\n";
+exit( 0 );


### PR DESCRIPTION
## Summary
- Link the logged-in hero username to the canonical Community profile
- Tag homepage destination links with the existing bridge URL/class contract
- Preserve and instrument existing profile-aware Community and owned-artist actions
- Replace the long `/power/` manifesto with a concise hero, live network doors, and one independence statement
- Remove duplicated manifesto pillars, artist conversion copy, and repeated closing CTA

## Why
The homepage should help returning members move through their own network identity, while `/power/` should let visitors experience the network instead of reading an explanation of it. Existing bridge analytics already own destination click/impression measurement, so this PR consumes that contract rather than adding instrumentation.

## Dependency
Requires Extra-Chill/extrachill-network#129 for bridge instrumentation to load on the homepage. Links degrade safely to ordinary navigation before that dependency ships.

## Verification
- `php tests/homepage-network-hub.php` passed
- `php tests/homepage-event-markets.php` passed
- Changed production PHP passes WordPress PHPCS
- PHP syntax and whitespace checks passed

Homeboy wrapper lint was deferred because an unrelated active WP Codebox run caused a production process storm; tracked in Extra-Chill/homeboy-extensions#2253.

Closes #61