### PR TITLE
Contextualize newsletter copy on entity-tagged stories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
             "php tests/homepage-event-markets.php",
             "php tests/festival-subscriptions.php",
             "php tests/artist-activity.php",
+            "php tests/newsletter-context.php",
             "@lint:php"
         ]
     },

--- a/extrachill-blog.php
+++ b/extrachill-blog.php
@@ -40,6 +40,7 @@ require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/artist-pillar.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/share-card.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/network-bridge.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/login-register-cta.php';
+require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/single/newsletter-context.php';
 
 /**
  * Register plugin styles

--- a/inc/single/newsletter-context.php
+++ b/inc/single/newsletter-context.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Contextual newsletter copy for single posts.
+ *
+ * @package ExtraChillBlog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tailor the existing post-content newsletter form to its primary entity.
+ *
+ * Only heading and description are changed. The content context and all other
+ * form arguments remain owned by Extra Chill Newsletter.
+ *
+ * @param array  $args    Newsletter form arguments.
+ * @param string $context Newsletter form context.
+ * @return array
+ */
+function extrachill_blog_contextualize_newsletter_form( $args, $context ) {
+	if (
+		'content' !== $context ||
+		! is_singular( 'post' ) ||
+		! function_exists( 'taxonomy_exists' ) ||
+		! function_exists( 'wp_get_post_terms' )
+	) {
+		return $args;
+	}
+
+	$entities = array(
+		'artist'   => array(
+			'heading'     => /* translators: %s: artist name. */ __( 'Keep up with %s', 'extrachill-blog' ),
+			'description' => /* translators: %s: artist name. */ __( 'Get the latest stories about %s, plus independent music coverage from Extra Chill.', 'extrachill-blog' ),
+		),
+		'festival' => array(
+			'heading'     => /* translators: %s: festival name. */ __( 'Stay in the %s loop', 'extrachill-blog' ),
+			'description' => /* translators: %s: festival name. */ __( 'Get %s news and festival updates, plus the best of Extra Chill.', 'extrachill-blog' ),
+		),
+		'location' => array(
+			'heading'     => /* translators: %s: location name. */ __( 'Stay connected to the %s music scene', 'extrachill-blog' ),
+			'description' => /* translators: %s: location name. */ __( 'Get music news from %s and beyond, delivered by Extra Chill.', 'extrachill-blog' ),
+		),
+	);
+
+	foreach ( $entities as $taxonomy => $copy ) {
+		if ( ! taxonomy_exists( $taxonomy ) ) {
+			continue;
+		}
+
+		$terms = wp_get_post_terms(
+			get_the_ID(),
+			$taxonomy,
+			array(
+				'orderby' => 'name',
+				'order'   => 'ASC',
+			)
+		);
+
+		if ( is_wp_error( $terms ) || empty( $terms ) || ! isset( $terms[0]->name ) ) {
+			continue;
+		}
+
+		$args['heading']     = sprintf( $copy['heading'], $terms[0]->name );
+		$args['description'] = sprintf( $copy['description'], $terms[0]->name );
+		break;
+	}
+
+	return $args;
+}
+add_filter( 'extrachill_newsletter_form_args', 'extrachill_blog_contextualize_newsletter_form', 10, 2 );

--- a/inc/single/newsletter-context.php
+++ b/inc/single/newsletter-context.php
@@ -29,20 +29,18 @@ function extrachill_blog_contextualize_newsletter_form( $args, $context ) {
 		return $args;
 	}
 
-	$entities = array(
+	$entities    = array(
 		'artist'   => array(
-			'heading'     => /* translators: %s: artist name. */ __( 'Keep up with %s', 'extrachill-blog' ),
-			'description' => /* translators: %s: artist name. */ __( 'Get the latest stories about %s, plus independent music coverage from Extra Chill.', 'extrachill-blog' ),
+			'heading' => /* translators: %s: artist name. */ __( 'Into %s?', 'extrachill-blog' ),
 		),
 		'festival' => array(
-			'heading'     => /* translators: %s: festival name. */ __( 'Stay in the %s loop', 'extrachill-blog' ),
-			'description' => /* translators: %s: festival name. */ __( 'Get %s news and festival updates, plus the best of Extra Chill.', 'extrachill-blog' ),
+			'heading' => /* translators: %s: festival name. */ __( 'Following %s?', 'extrachill-blog' ),
 		),
 		'location' => array(
-			'heading'     => /* translators: %s: location name. */ __( 'Stay connected to the %s music scene', 'extrachill-blog' ),
-			'description' => /* translators: %s: location name. */ __( 'Get music news from %s and beyond, delivered by Extra Chill.', 'extrachill-blog' ),
+			'heading' => /* translators: %s: location name. */ __( 'Into the %s music scene?', 'extrachill-blog' ),
 		),
 	);
+	$description = __( 'Get independent music stories, news, and events from Extra Chill.', 'extrachill-blog' );
 
 	foreach ( $entities as $taxonomy => $copy ) {
 		if ( ! taxonomy_exists( $taxonomy ) ) {
@@ -63,7 +61,7 @@ function extrachill_blog_contextualize_newsletter_form( $args, $context ) {
 		}
 
 		$args['heading']     = sprintf( $copy['heading'], $terms[0]->name );
-		$args['description'] = sprintf( $copy['description'], $terms[0]->name );
+		$args['description'] = $description;
 		break;
 	}
 

--- a/tests/newsletter-context.php
+++ b/tests/newsletter-context.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Focused tests for contextual post-content newsletter copy.
+ *
+ * Run with: php tests/newsletter-context.php
+ */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+class WP_Error {}
+
+class WP_Term {
+	public $name;
+
+	public function __construct( $name ) {
+		$this->name = $name;
+	}
+}
+
+$test_is_post    = true;
+$test_taxonomies = array( 'artist', 'festival', 'location' );
+$test_terms      = array();
+$test_term_args  = array();
+
+function add_filter() {}
+function is_singular( $post_type ) {
+	global $test_is_post;
+	return 'post' === $post_type && $test_is_post;
+}
+function taxonomy_exists( $taxonomy ) {
+	global $test_taxonomies;
+	return in_array( $taxonomy, $test_taxonomies, true );
+}
+function wp_get_post_terms( $post_id, $taxonomy, $args ) {
+	global $test_term_args, $test_terms;
+	$test_term_args[ $taxonomy ] = $args;
+	return $test_terms[ $taxonomy ] ?? array();
+}
+function get_the_ID() {
+	return 65;
+}
+function is_wp_error( $value ) {
+	return $value instanceof WP_Error;
+}
+function __( $text ) {
+	return $text;
+}
+function esc_html( $text ) {
+	return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+}
+
+require_once dirname( __DIR__ ) . '/inc/single/newsletter-context.php';
+
+function assert_same( $expected, $actual, $message ) {
+	if ( $expected !== $actual ) {
+		fwrite( STDERR, $message . "\n" );
+		exit( 1 );
+	}
+}
+
+function newsletter_args() {
+	return array(
+		'heading'           => 'Generic heading',
+		'description'       => 'Generic description',
+		'wrapper_class'     => 'newsletter-content-section',
+		'heading_level'     => 'h3',
+		'layout'            => 'section',
+		'placeholder'       => 'Enter your email address',
+		'button_text'       => 'Subscribe',
+		'show_archive_link' => true,
+		'archive_link_text' => 'Browse past newsletters',
+	);
+}
+
+function contextualize( $terms, $context = 'content' ) {
+	global $test_terms;
+	$test_terms = $terms;
+	return extrachill_blog_contextualize_newsletter_form( newsletter_args(), $context );
+}
+
+$artist = contextualize( array( 'artist' => array( new WP_Term( 'Kid Lake' ) ) ) );
+assert_same( 'Keep up with Kid Lake', $artist['heading'], 'Artist terms should set artist copy.' );
+assert_same( 'Get the latest stories about Kid Lake, plus independent music coverage from Extra Chill.', $artist['description'], 'Artist description should use the artist name.' );
+
+$festival = contextualize( array( 'festival' => array( new WP_Term( 'High Water' ) ) ) );
+assert_same( 'Stay in the High Water loop', $festival['heading'], 'Festival terms should set festival copy.' );
+assert_same( 'Get High Water news and festival updates, plus the best of Extra Chill.', $festival['description'], 'Festival description should use the festival name.' );
+
+$location = contextualize( array( 'location' => array( new WP_Term( 'Charleston' ) ) ) );
+assert_same( 'Stay connected to the Charleston music scene', $location['heading'], 'Location terms should set location copy.' );
+assert_same( 'Get music news from Charleston and beyond, delivered by Extra Chill.', $location['description'], 'Location description should use the location name.' );
+
+$mixed = contextualize(
+	array(
+		'location' => array( new WP_Term( 'Charleston' ) ),
+		'festival' => array( new WP_Term( 'High Water' ) ),
+		'artist'   => array( new WP_Term( 'Kid Lake' ) ),
+	)
+);
+assert_same( 'Keep up with Kid Lake', $mixed['heading'], 'Artist copy should win the mixed-term priority.' );
+assert_same( array( 'orderby' => 'name', 'order' => 'ASC' ), $test_term_args['artist'], 'Entity terms should use deterministic name ordering.' );
+
+$original           = newsletter_args();
+$test_taxonomies    = array();
+$missing_dependency = contextualize( array( 'artist' => array( new WP_Term( 'Kid Lake' ) ) ) );
+assert_same( $original, $missing_dependency, 'Missing taxonomy dependencies should preserve generic form arguments.' );
+$test_taxonomies = array( 'artist', 'festival', 'location' );
+
+assert_same( $original, contextualize( array() ), 'Posts without entity terms should retain generic copy.' );
+assert_same( $original, contextualize( array( 'artist' => new WP_Error() ) ), 'Term lookup errors should retain generic copy.' );
+assert_same( $original, contextualize( array( 'artist' => array( new WP_Term( 'Kid Lake' ) ) ), 'archive' ), 'Non-content forms should remain unchanged.' );
+
+$test_is_post = false;
+assert_same( $original, contextualize( array( 'artist' => array( new WP_Term( 'Kid Lake' ) ) ) ), 'Non-post views should remain unchanged.' );
+$test_is_post = true;
+
+$escaped = contextualize( array( 'artist' => array( new WP_Term( '<script>alert("x")</script> & Friends' ) ) ) );
+$rendered = '<h3>' . esc_html( $escaped['heading'] ) . '</h3><p>' . esc_html( $escaped['description'] ) . '</p>';
+assert_same( false, false !== strpos( $rendered, '<script>' ), 'Rendered contextual copy must escape term markup.' );
+assert_same( true, false !== strpos( $rendered, '&lt;script&gt;' ), 'Rendered contextual copy should retain escaped term text.' );
+
+$preserved = $mixed;
+unset( $preserved['heading'], $preserved['description'] );
+$expected = $original;
+unset( $expected['heading'], $expected['description'] );
+assert_same( $expected, $preserved, 'Contextual copy must preserve every non-copy form argument.' );
+
+fwrite( STDOUT, "Newsletter context tests passed.\n" );

--- a/tests/newsletter-context.php
+++ b/tests/newsletter-context.php
@@ -79,16 +79,16 @@ function contextualize( $terms, $context = 'content' ) {
 }
 
 $artist = contextualize( array( 'artist' => array( new WP_Term( 'Kid Lake' ) ) ) );
-assert_same( 'Keep up with Kid Lake', $artist['heading'], 'Artist terms should set artist copy.' );
-assert_same( 'Get the latest stories about Kid Lake, plus independent music coverage from Extra Chill.', $artist['description'], 'Artist description should use the artist name.' );
+assert_same( 'Into Kid Lake?', $artist['heading'], 'Artist terms should set artist copy.' );
+assert_same( 'Get independent music stories, news, and events from Extra Chill.', $artist['description'], 'Artist context should not promise artist-specific delivery.' );
 
 $festival = contextualize( array( 'festival' => array( new WP_Term( 'High Water' ) ) ) );
-assert_same( 'Stay in the High Water loop', $festival['heading'], 'Festival terms should set festival copy.' );
-assert_same( 'Get High Water news and festival updates, plus the best of Extra Chill.', $festival['description'], 'Festival description should use the festival name.' );
+assert_same( 'Following High Water?', $festival['heading'], 'Festival terms should set festival copy.' );
+assert_same( 'Get independent music stories, news, and events from Extra Chill.', $festival['description'], 'Festival context should not promise festival-specific delivery.' );
 
 $location = contextualize( array( 'location' => array( new WP_Term( 'Charleston' ) ) ) );
-assert_same( 'Stay connected to the Charleston music scene', $location['heading'], 'Location terms should set location copy.' );
-assert_same( 'Get music news from Charleston and beyond, delivered by Extra Chill.', $location['description'], 'Location description should use the location name.' );
+assert_same( 'Into the Charleston music scene?', $location['heading'], 'Location terms should set location copy.' );
+assert_same( 'Get independent music stories, news, and events from Extra Chill.', $location['description'], 'Location context should not promise location-specific delivery.' );
 
 $mixed = contextualize(
 	array(
@@ -97,7 +97,7 @@ $mixed = contextualize(
 		'artist'   => array( new WP_Term( 'Kid Lake' ) ),
 	)
 );
-assert_same( 'Keep up with Kid Lake', $mixed['heading'], 'Artist copy should win the mixed-term priority.' );
+assert_same( 'Into Kid Lake?', $mixed['heading'], 'Artist copy should win the mixed-term priority.' );
 assert_same( array( 'orderby' => 'name', 'order' => 'ASC' ), $test_term_args['artist'], 'Entity terms should use deterministic name ordering.' );
 
 $original           = newsletter_args();


### PR DESCRIPTION
## Summary
- customize only the existing `content` newsletter form heading and description for artist, festival, and location terms
- apply deterministic `artist > festival > location` priority and name ordering, with the generic preset retained whenever context is unavailable
- preserve the existing context, list mapping, form markup, submission path, analytics, placement, and escaping
- cover each entity, mixed priority, missing dependencies, escaping/rendering, unchanged arguments, and generic fallbacks

## Testing
- `php tests/homepage-event-markets.php`
- `php tests/festival-subscriptions.php`
- `php tests/artist-activity.php`
- `php tests/newsletter-context.php`
- `php -l inc/single/newsletter-context.php`
- `php -l tests/newsletter-context.php`
- `php -l extrachill-blog.php`
- `vendor/bin/phpcs --standard=WordPress inc/single/newsletter-context.php extrachill-blog.php`
- `git diff --check`

`composer test` passes all behavioral scripts, then reaches existing PHPCS failures in untouched files: `inc/single/login-register-cta.php`, `inc/core/co-authors.php`, `inc/core/ads-filter.php`, and `inc/core/admin-customizations.php`.

Closes #65