### PR TITLE
feat: bridge geographic stories to local network surfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
             "php tests/festival-subscriptions.php",
             "php tests/artist-activity.php",
             "php tests/newsletter-context.php",
+            "php tests/network-bridge.php",
             "@lint:php"
         ]
     },

--- a/inc/single/network-bridge.php
+++ b/inc/single/network-bridge.php
@@ -7,11 +7,10 @@
  * breathe daily: the artist's profile hub, the events calendar, the festival
  * news wire, the shop, and the community.
  *
- * The bridge itself — terms resolution, transient caching, slot assembly, UTM
- * tagging, and render markup — lives in the shared primitive
- * `extrachill_render_network_bridge()` in extrachill-multisite. This file is a
- * thin hook that decides WHEN to render (single `post` views) and passes the
- * blog's per-site arguments. The shared primitive owns the rest.
+ * Cross-site resolution, transient caching, UTM tagging, and card rendering
+ * stay in the shared Network primitives. This consumer only gives artist and
+ * festival cards priority, then lets location and venue cards fill vacant
+ * Events or Community slots.
  *
  * @package ExtraChillBlog
  * @since 0.4.0
@@ -22,34 +21,111 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Render the "From Around the Extra Chill Network" section on single posts.
+ * Build the publication bridge configuration.
+ *
+ * @return array Bridge configuration.
+ */
+function extrachill_blog_network_bridge_args() {
+	return array(
+		'post_id'           => get_the_ID(),
+		'allowed_site_keys' => array( 'artist', 'events', 'wire', 'shop', 'community' ),
+		'slot_order'        => array( 'artist', 'events', 'wire', 'shop', 'community' ),
+		'utm_source'        => 'extrachill_blog',
+		'cache_prefix'      => 'ec_blog_network_bridge_',
+		'heading_id'        => 'network-bridge-header',
+		'heading_text'      => __( 'From Around the Extra Chill Network', 'extrachill-blog' ),
+	);
+}
+
+/**
+ * Resolve primary cards, then fill vacant geographic destination slots.
+ *
+ * Geography is bounded to Events and Community. Resolving it separately keeps
+ * broad location counts from displacing artist or festival cards for the same
+ * destination. Both passes use Network's verified resolver and cache path.
+ *
+ * @param array $args Bridge configuration.
+ * @return array Ordered bridge cards.
+ */
+function extrachill_blog_network_bridge_cards( $args ) {
+	$primary_cards = extrachill_network_bridge_get_cards(
+		$args['post_id'],
+		array( 'artist', 'festival' ),
+		$args['allowed_site_keys'],
+		$args['slot_order'],
+		$args['utm_source'],
+		$args['cache_prefix']
+	);
+	$by_site       = array();
+
+	foreach ( $primary_cards as $card ) {
+		if ( ! empty( $card['site_key'] ) ) {
+			$by_site[ $card['site_key'] ] = $card;
+		}
+	}
+
+	$geographic_slots = array( 'events', 'community' );
+	if ( array_diff( $geographic_slots, array_keys( $by_site ) ) ) {
+		$geographic_cards = extrachill_network_bridge_get_cards(
+			$args['post_id'],
+			array( 'location', 'venue' ),
+			$geographic_slots,
+			$geographic_slots,
+			$args['utm_source'],
+			$args['cache_prefix'] . 'geographic_'
+		);
+
+		foreach ( $geographic_cards as $card ) {
+			$site_key = isset( $card['site_key'] ) ? $card['site_key'] : '';
+			if ( in_array( $site_key, $geographic_slots, true ) && ! isset( $by_site[ $site_key ] ) ) {
+				$by_site[ $site_key ] = $card;
+			}
+		}
+	}
+
+	$cards = array();
+	foreach ( $args['slot_order'] as $site_key ) {
+		if ( isset( $by_site[ $site_key ] ) ) {
+			$cards[] = $by_site[ $site_key ];
+		}
+	}
+
+	return $cards;
+}
+
+/**
+ * Render the geographic-aware bridge on single posts.
  *
  * Hooked at priority 6 on `extrachill_after_post_content` so it renders just
- * after the share card (priority 5). Guarded to single `post` views.
- *
- * Renders NOTHING when the post carries no artist/festival terms or when no
- * cross-site content matches (no empty box) — that behavior lives in the
- * shared primitive.
+ * after the share card (priority 5). Renders nothing when no verified
+ * cross-site destination resolves.
  */
 function extrachill_blog_network_bridge() {
 	if ( ! is_singular( 'post' ) ) {
 		return;
 	}
 
-	if ( ! function_exists( 'extrachill_render_network_bridge' ) ) {
+	if ( ! function_exists( 'extrachill_network_bridge_get_cards' )
+		|| ! function_exists( 'extrachill_cross_site_link_button' ) ) {
 		return;
 	}
 
-	extrachill_render_network_bridge(
-		array(
-			'post_id'           => get_the_ID(),
-			'taxonomies'        => array( 'artist', 'festival' ),
-			'allowed_site_keys' => array( 'artist', 'events', 'wire', 'shop', 'community' ),
-			'slot_order'        => array( 'artist', 'events', 'wire', 'shop', 'community' ),
-			'utm_source'        => 'extrachill_blog',
-			'cache_prefix'      => 'ec_blog_network_bridge_',
-			'heading_id'        => 'network-bridge-header',
-		)
-	);
+	$args  = extrachill_blog_network_bridge_args();
+	$cards = extrachill_blog_network_bridge_cards( $args );
+	if ( empty( $cards ) ) {
+		return;
+	}
+
+	wp_enqueue_style( 'extrachill-network-bridge' );
+	?>
+	<div class="network-bridge-section related-tax-section" aria-labelledby="<?php echo esc_attr( $args['heading_id'] ); ?>">
+		<h3 class="network-bridge-header related-tax-header" id="<?php echo esc_attr( $args['heading_id'] ); ?>"><?php echo esc_html( $args['heading_text'] ); ?></h3>
+		<div class="network-bridge-links ec-cross-site-links">
+			<?php foreach ( $cards as $card ) : ?>
+				<?php extrachill_cross_site_link_button( $card, 'network-bridge-link' ); ?>
+			<?php endforeach; ?>
+		</div>
+	</div>
+	<?php
 }
 add_action( 'extrachill_after_post_content', 'extrachill_blog_network_bridge', 6 );

--- a/tests/network-bridge.php
+++ b/tests/network-bridge.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Focused tests for geographic single-post bridge fallback.
+ *
+ * Run with: php tests/network-bridge.php
+ *
+ * @package ExtraChillBlog
+ */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+// Test doubles intentionally mirror WordPress and shared renderer signatures.
+// phpcs:disable Squiz.Commenting.FunctionComment.Missing,Squiz.Commenting.FunctionComment.MissingParamTag,WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid,Universal.NamingConventions.NoReservedKeywordParameterNames.classFound
+
+$test_cards_by_taxonomy = array();
+$test_resolver_calls    = array();
+$test_is_post           = true;
+$test_enqueued_styles   = array();
+
+/** Stub action registration. */
+function add_action() {}
+
+/** Stub current post ID. */
+function get_the_ID() {
+	return 64;
+}
+
+/** Stub singular post context. */
+function is_singular( $post_type ) {
+	global $test_is_post;
+	return 'post' === $post_type && $test_is_post;
+}
+
+/** Stub translation. */
+function __( $text ) {
+	return $text;
+}
+
+/** Stub attribute escaping. */
+function esc_attr( $text ) {
+	return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+}
+
+/** Stub HTML escaping. */
+function esc_html( $text ) {
+	return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+}
+
+/** Stub URL escaping. */
+function esc_url( $url ) {
+	return htmlspecialchars( $url, ENT_QUOTES, 'UTF-8' );
+}
+
+/** Capture enqueued styles. */
+function wp_enqueue_style( $handle ) {
+	global $test_enqueued_styles;
+	$test_enqueued_styles[] = $handle;
+}
+
+/** Stub the shared verified resolver and capture its contract. */
+function extrachill_network_bridge_get_cards( $post_id, $taxonomies, $allowed_site_keys, $slot_order, $utm_source, $cache_prefix ) {
+	global $test_cards_by_taxonomy, $test_resolver_calls;
+	$key                   = implode( ',', $taxonomies );
+	$test_resolver_calls[] = array(
+		'post_id'           => $post_id,
+		'taxonomies'        => $taxonomies,
+		'allowed_site_keys' => $allowed_site_keys,
+		'slot_order'        => $slot_order,
+		'utm_source'        => $utm_source,
+		'cache_prefix'      => $cache_prefix,
+	);
+
+	return $test_cards_by_taxonomy[ $key ] ?? array();
+}
+
+/** Stub the shared escaped card renderer. */
+function extrachill_cross_site_link_button( $card, $class = '' ) {
+	if ( empty( $card['url'] ) || empty( $card['label'] ) ) {
+		return;
+	}
+
+	printf(
+		'<a href="%s" class="button-3 button-small ec-cross-site-link %s">%s %s</a>',
+		esc_url( $card['url'] ),
+		esc_attr( $class ),
+		esc_html( $card['term_name'] ?? '' ),
+		esc_html( $card['label'] )
+	);
+}
+
+require_once dirname( __DIR__ ) . '/inc/single/network-bridge.php';
+
+/** Assert strict equality. */
+function assert_same( $expected, $actual, $message ) {
+	if ( $expected !== $actual ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- CLI test failure output.
+		fwrite( STDERR, $message . "\n" );
+		exit( 1 );
+	}
+}
+
+/** Build a card shaped like a verified Network resolver result. */
+function bridge_card( $site_key, $term_name, $taxonomy ) {
+	return array(
+		'site_key'  => $site_key,
+		'url'       => 'https://' . $site_key . '.extrachill.test/' . $taxonomy . '/' . strtolower( str_replace( ' ', '-', $term_name ) ) . '?utm_medium=network_bridge',
+		'label'     => ucfirst( $site_key ),
+		'term_name' => $term_name,
+		'count'     => 1,
+	);
+}
+
+/** Resolve cards with controlled primary and geographic results. */
+function resolve_cards( $primary, $geographic ) {
+	global $test_cards_by_taxonomy, $test_resolver_calls;
+	$test_cards_by_taxonomy = array(
+		'artist,festival' => $primary,
+		'location,venue'  => $geographic,
+	);
+	$test_resolver_calls    = array();
+
+	return extrachill_blog_network_bridge_cards( extrachill_blog_network_bridge_args() );
+}
+
+$artist_event = bridge_card( 'events', 'Kid Lake', 'artist' );
+$city_event   = bridge_card( 'events', 'Charleston', 'location' );
+$community    = bridge_card( 'community', 'Charleston', 'location' );
+$cards        = resolve_cards( array( $artist_event ), array( $city_event, $community ) );
+assert_same( 'Kid Lake', $cards[0]['term_name'], 'Artist cards must retain an occupied Events slot.' );
+assert_same( 'Charleston', $cards[1]['term_name'], 'Geography should fill the vacant Community slot.' );
+assert_same( array( 'events', 'community' ), $test_resolver_calls[1]['allowed_site_keys'], 'Geographic resolution must remain bounded to Events and Community.' );
+
+$primary_community = bridge_card( 'community', 'Kid Lake', 'artist' );
+$cards             = resolve_cards( array( $artist_event, $primary_community ), array( $city_event, $community ) );
+assert_same( 1, count( $test_resolver_calls ), 'Geography must not resolve when primary cards occupy all fallback capacity.' );
+
+$cards = resolve_cards( array(), array( $city_event, $community ) );
+assert_same( array( 'events', 'community' ), array_column( $cards, 'site_key' ), 'Geography should provide verified fallback cards when primary entities do not resolve.' );
+assert_same( 'ec_blog_network_bridge_geographic_', $test_resolver_calls[1]['cache_prefix'], 'Geography should use the shared cache path with a stable dedicated prefix.' );
+
+$artist_profile = bridge_card( 'artist', 'Kid Lake', 'artist' );
+$festival_wire  = bridge_card( 'wire', 'High Water', 'festival' );
+$cards          = resolve_cards( array( $artist_profile, $festival_wire ), array( $city_event, $community ) );
+assert_same( array( 'artist', 'events', 'wire', 'community' ), array_column( $cards, 'site_key' ), 'Mixed terms should preserve slot order while geography only fills capacity.' );
+assert_same( 'High Water', $cards[2]['term_name'], 'A location card must not displace a primary festival destination.' );
+
+$cards = resolve_cards( array(), array() );
+assert_same( array(), $cards, 'Posts without a verified destination must fail closed.' );
+ob_start();
+extrachill_blog_network_bridge();
+$empty_output = ob_get_clean();
+assert_same( '', $empty_output, 'No-result bridges must render no empty container.' );
+
+resolve_cards( array(), array( $city_event ) );
+ob_start();
+extrachill_blog_network_bridge();
+$mobile_output = ob_get_clean();
+assert_same( true, false !== strpos( $mobile_output, 'network-bridge-links ec-cross-site-links' ), 'Bridge output should retain the existing responsive link-row classes.' );
+assert_same( true, false !== strpos( $mobile_output, 'button-3 button-small ec-cross-site-link network-bridge-link' ), 'Mobile cards should use the shared compact card renderer.' );
+assert_same( true, in_array( 'extrachill-network-bridge', $test_enqueued_styles, true ), 'A rendered bridge should enqueue the shared responsive stylesheet.' );
+assert_same( true, false !== strpos( $mobile_output, 'utm_medium=network_bridge' ), 'Rendered destinations should retain shared UTM instrumentation.' );
+
+fwrite( STDOUT, "Network bridge tests passed.\n" ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- CLI test output.


### PR DESCRIPTION
## Summary
- resolve artist and festival destinations first, then let location and venue context fill only vacant Events or Community slots
- reuse the Network verified resolver, transient/UTM path, shared card renderer, responsive classes, and click/impression instrumentation
- fail closed when Network resolves no real destination; no endpoint, bridge substrate, or local destination registry is added

## Priority and capacity
The existing five-site slot order remains `artist`, `events`, `wire`, `shop`, `community`. Artist/festival cards claim those slots first. Geographic resolution is bounded to the `events` and `community` destination keys and only runs when at least one of those slots remains vacant; it never replaces a primary card, even when a broad location has a larger count.

Mixed posts therefore retain their primary artist/festival destinations while verified geography fills remaining local-discovery capacity. Posts whose primary cards already occupy both geographic slots skip the fallback pass entirely.

## Verification and behavior
Both passes use `extrachill_network_bridge_get_cards()`, so destinations must pass Extra Chill Network's existing term/content verification. The original primary cache prefix is preserved, geography uses a stable dedicated prefix through the same transient path, and URLs retain the shared `utm_source=extrachill_blog`, `utm_medium=network_bridge`, and destination campaign tagging. Cards render through `extrachill_cross_site_link_button()`, preserving escaping, mobile wrapping classes, and `ec-cross-site-link` click instrumentation. Empty resolver results render no section.

Focused coverage includes artist priority, no-capacity short-circuiting, geographic fallback, mixed terms, no valid destination, cache/UTM reuse, and mobile card markup.

Commands run:
- `php tests/network-bridge.php` (pass)
- `php -l inc/single/network-bridge.php && php -l tests/network-bridge.php` (pass)
- `vendor/bin/phpcs --standard=WordPress inc/single/network-bridge.php tests/network-bridge.php` (pass)
- `composer validate --no-check-publish` (valid; system Composer emitted PHP deprecation notices)
- `git diff --check` (pass)
- `composer test` (all five standalone test suites pass; the final repository-wide PHPCS step remains blocked by pre-existing violations in untouched `inc/single/login-register-cta.php`, `inc/core/co-authors.php`, `inc/core/ads-filter.php`, and `inc/core/admin-customizations.php`)

Closes #64