### PR TITLE
feat: run geographic bridge holdout

### DIFF
--- a/assets/css/artist-dispatch.css
+++ b/assets/css/artist-dispatch.css
@@ -1,0 +1,209 @@
+.artist-dispatch-page,
+.artist-dispatch-guidelines,
+.artist-dispatch-write {
+	--dispatch-border: color-mix(in srgb, var(--text-color) 18%, transparent);
+	max-width: 920px;
+	margin: 0 auto;
+}
+
+.artist-dispatch-hero {
+	padding: clamp(2.5rem, 8vw, 6rem) 0 clamp(2rem, 5vw, 4rem);
+	border-bottom: 1px solid var(--dispatch-border);
+}
+
+.artist-dispatch-hero h1,
+.artist-dispatch-guidelines h1 {
+	font-size: clamp(3rem, 9vw, 6.5rem);
+	line-height: .9;
+	letter-spacing: -.065em;
+	margin: .2em 0;
+}
+
+.artist-dispatch-hero > p:last-child,
+.artist-dispatch-guidelines header > p:last-child {
+	font-size: clamp(1.1rem, 2vw, 1.4rem);
+	max-width: 720px;
+}
+
+.artist-dispatch-kicker,
+.artist-dispatch-label {
+	font-size: .75rem;
+	font-weight: 800;
+	letter-spacing: .12em;
+	text-transform: uppercase;
+	color: var(--accent);
+}
+
+.artist-dispatch-panel,
+.artist-dispatch-state,
+.artist-dispatch-dashboard {
+	margin: 2rem 0;
+	padding: clamp(1.25rem, 4vw, 2.5rem);
+	background: var(--card-background);
+	border: 1px solid var(--dispatch-border);
+	border-radius: var(--border-radius-large);
+}
+
+.artist-dispatch-panel p,
+.artist-dispatch-state > p {
+	max-width: 740px;
+}
+
+.artist-dispatch-actions,
+.artist-dispatch-dashboard__head,
+.artist-dispatch-editor-actions {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+	flex-wrap: wrap;
+}
+
+.artist-dispatch-form {
+	display: grid;
+	gap: 1.25rem;
+	max-width: 680px;
+}
+
+.artist-dispatch-form label:not(.artist-dispatch-check) {
+	display: grid;
+	gap: .45rem;
+	font-weight: 700;
+}
+
+.artist-dispatch-form input,
+.artist-dispatch-form select,
+.artist-dispatch-form textarea {
+	width: 100%;
+	box-sizing: border-box;
+	padding: .8rem;
+	color: var(--text-color);
+	background: var(--body-background);
+	border: 1px solid var(--dispatch-border);
+	border-radius: var(--border-radius-small);
+}
+
+.artist-dispatch-form textarea {
+	min-height: 150px;
+}
+
+.artist-dispatch-check {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	gap: .75rem;
+}
+
+.artist-dispatch-message {
+	min-height: 1.5em;
+}
+
+.artist-dispatch-criteria,
+.artist-dispatch-group ul {
+	list-style: none;
+	padding: 0;
+}
+
+.artist-dispatch-criteria li,
+.artist-dispatch-group li {
+	display: flex;
+	justify-content: space-between;
+	gap: 1rem;
+	padding: .85rem 0;
+	border-bottom: 1px solid var(--dispatch-border);
+}
+
+.artist-dispatch-criteria li span,
+.artist-dispatch-group li span {
+	display: block;
+	font-size: .85rem;
+	opacity: .72;
+}
+
+.artist-dispatch-criteria .is-met::before {
+	content: "✓";
+	color: var(--accent);
+	margin-right: .6rem;
+}
+
+.artist-dispatch-groups {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 1rem;
+}
+
+.artist-dispatch-group {
+	min-width: 0;
+}
+
+.artist-dispatch-guidelines header,
+.artist-dispatch-guidelines section {
+	padding: clamp(1.5rem, 4vw, 3rem) 0;
+	border-bottom: 1px solid var(--dispatch-border);
+}
+
+.artist-dispatch-guidelines section {
+	display: grid;
+	grid-template-columns: minmax(180px, 1fr) 2fr;
+	gap: 2rem;
+}
+
+.artist-dispatch-guidelines h2,
+.artist-dispatch-guidelines p {
+	margin-top: 0;
+}
+
+.artist-dispatch-write {
+	max-width: 1100px;
+}
+
+.artist-dispatch-write__intro {
+	padding: 1rem 0;
+}
+
+.artist-dispatch-editor {
+	min-height: 70vh;
+	background: var(--card-background);
+	border: 1px solid var(--dispatch-border);
+	border-radius: var(--border-radius-large);
+	overflow: hidden;
+}
+
+.artist-dispatch-editor-title {
+	width: 100%;
+	padding: 1rem clamp(1rem, 4vw, 3rem) 0;
+	box-sizing: border-box;
+}
+
+.artist-dispatch-editor-actions {
+	width: 100%;
+}
+
+.artist-dispatch-save-state {
+	display: inline-flex;
+	align-items: center;
+	gap: .4rem;
+	margin-right: auto;
+}
+
+.artist-dispatch-disclosure {
+	padding: 1rem 1.25rem;
+	margin-bottom: 2rem;
+	background: var(--card-background);
+	border-left: 4px solid var(--accent);
+}
+
+.artist-dispatch-disclosure p {
+	margin: .35rem 0 0;
+}
+
+@media (max-width: 720px) {
+	.artist-dispatch-groups,
+	.artist-dispatch-guidelines section {
+		grid-template-columns: 1fr;
+		gap: .5rem;
+	}
+
+	.artist-dispatch-dashboard__head {
+		align-items: flex-start;
+	}
+}

--- a/assets/js/artist-dispatch-editor.js
+++ b/assets/js/artist-dispatch-editor.js
@@ -1,0 +1,97 @@
+( function () {
+	'use strict';
+
+	if ( ! window.blocksEverywhere || ! window.wp || ! window.wp.editor || ! window.ecArtistDispatchEditor ) {
+		return;
+	}
+
+	const el = window.wp.element.createElement;
+	const { useState } = window.wp.element;
+	const { useDispatch, useSelect } = window.wp.data;
+	const { Button, Spinner } = window.wp.components;
+	const editorStore = window.wp.editor.store;
+
+	function getSaveError() {
+		const editor = window.wp.data.select( editorStore );
+		if ( ! editor.didPostSaveRequestFail() || ! window.wp.coreData ) {
+			return null;
+		}
+		return window.wp.data.select( window.wp.coreData.store ).getLastEntitySaveError( 'postType', 'post', editor.getCurrentPostId() );
+	}
+
+	window.blocksEverywhere.registerSlotFill( 'heading', () => el(
+		'div',
+		{ className: 'artist-dispatch-editor-title' },
+		el( 'span', { className: 'artist-dispatch-label' }, 'Artist Dispatch' ),
+		el( window.wp.editor.PostTitle )
+	) );
+
+	function EditorActions() {
+		const [ message, setMessage ] = useState( '' );
+		const [ submitting, setSubmitting ] = useState( false );
+		const { editPost, savePost } = useDispatch( editorStore );
+		const state = useSelect( ( select ) => {
+			const editor = select( editorStore );
+			return {
+				saving: editor.isSavingPost(),
+				autosaving: editor.isAutosavingPost(),
+				dirty: editor.isEditedPostDirty(),
+			};
+		}, [] );
+
+		const saveDraft = async () => {
+			setMessage( 'Saving…' );
+			try {
+				await savePost();
+				const error = getSaveError();
+				if ( error ) {
+					throw error;
+				}
+				setMessage( 'Draft saved.' );
+			} catch ( error ) {
+				setMessage( error && error.message ? error.message : 'Draft save failed.' );
+			}
+		};
+
+		const submit = async () => {
+			if ( submitting ) {
+				return;
+			}
+			setSubmitting( true );
+			setMessage( 'Submitting for editorial review…' );
+			try {
+				editPost( { status: 'pending' } );
+				await savePost();
+				const error = getSaveError();
+				if ( error ) {
+					throw error;
+				}
+				window.location.assign( window.ecArtistDispatchEditor.dashboardUrl );
+			} catch ( error ) {
+				editPost( { status: 'draft' } );
+				setMessage( error && error.message ? error.message : 'Submission failed. Your draft remains private.' );
+				setSubmitting( false );
+			}
+		};
+
+		const busy = state.saving || state.autosaving || submitting;
+		let status = message;
+		if ( state.autosaving ) {
+			status = 'Autosaving…';
+		} else if ( ! message && state.dirty ) {
+			status = 'Unsaved changes';
+		} else if ( ! message ) {
+			status = 'All changes saved';
+		}
+
+		return el(
+			'div',
+			{ className: 'artist-dispatch-editor-actions' },
+			el( 'span', { className: 'artist-dispatch-save-state', role: 'status' }, busy && el( Spinner ), status ),
+			el( Button, { variant: 'secondary', disabled: busy || ! state.dirty, onClick: saveDraft }, 'Save Draft' ),
+			el( Button, { variant: 'primary', disabled: busy, onClick: submit }, 'Submit for Review' )
+		);
+	}
+
+	window.blocksEverywhere.registerSlotFill( 'footer', () => el( EditorActions ) );
+}() );

--- a/assets/js/artist-dispatch.js
+++ b/assets/js/artist-dispatch.js
@@ -1,0 +1,82 @@
+( function () {
+	'use strict';
+
+	if ( ! window.wp || ! window.wp.apiFetch || ! window.ecArtistDispatch ) {
+		return;
+	}
+
+	const apiFetch = window.wp.apiFetch;
+	apiFetch.use( apiFetch.createNonceMiddleware( window.ecArtistDispatch.nonce ) );
+
+	const requestForm = document.getElementById( 'artist-dispatch-request' );
+	if ( requestForm ) {
+		requestForm.addEventListener( 'submit', async ( event ) => {
+			event.preventDefault();
+			const button = requestForm.querySelector( 'button[type="submit"]' );
+			const message = requestForm.querySelector( '.artist-dispatch-message' );
+			const data = new window.FormData( requestForm );
+			button.disabled = true;
+			message.textContent = 'Sending your request…';
+
+			try {
+				const input = {
+					artist_id: Number( data.get( 'artist_id' ) ),
+					description: String( data.get( 'description' ) || '' ),
+					acknowledgement: data.get( 'acknowledgement' ) === 'on',
+					terms_version: window.ecArtistDispatch.termsVersion,
+				};
+				const sampleUrl = String( data.get( 'sample_url' ) || '' );
+				if ( sampleUrl ) {
+					input.sample_url = sampleUrl;
+				}
+				await apiFetch( {
+					path: '/wp-abilities/v1/abilities/extrachill/request-artist-dispatch-access/run',
+					method: 'POST',
+					data: { input },
+				} );
+				message.textContent = 'Your request is in the editorial queue.';
+				window.location.reload();
+			} catch ( error ) {
+				message.textContent = error && error.message ? error.message : 'The request could not be sent. Please try again.';
+				button.disabled = false;
+			}
+		} );
+	}
+
+	const newButton = document.getElementById( 'artist-dispatch-new' );
+	if ( newButton ) {
+		let creationPromise = null;
+		newButton.addEventListener( 'click', () => {
+			if ( creationPromise ) {
+				return creationPromise;
+			}
+			const message = document.getElementById( 'artist-dispatch-new-message' );
+			newButton.disabled = true;
+			message.textContent = 'Creating your private draft…';
+
+			creationPromise = apiFetch( {
+				path: '/wp/v2/posts',
+				method: 'POST',
+				data: {
+					title: '',
+					content: '',
+					status: 'draft',
+				},
+				headers: { 'X-Extra-Chill-Artist-Dispatch': 'create' },
+			} )
+				.then( ( post ) => {
+					if ( ! post || ! post.id ) {
+						throw new Error( 'WordPress did not return a draft ID.' );
+					}
+					window.location.assign( `${ window.ecArtistDispatch.writeUrl }?post=${ Number( post.id ) }` );
+				} )
+				.catch( ( error ) => {
+					message.textContent = error && error.message ? error.message : 'The draft could not be created. Please try again.';
+					newButton.disabled = false;
+					creationPromise = null;
+				} );
+
+			return creationPromise;
+		} );
+	}
+}() );

--- a/assets/js/geographic-bridge-experiment.js
+++ b/assets/js/geographic-bridge-experiment.js
@@ -1,0 +1,47 @@
+/**
+ * Reveal inert geographic bridge candidates for measured treatment assignments.
+ */
+( function () {
+	function activate( section ) {
+		if ( ! section || ! section.querySelectorAll ) {
+			return;
+		}
+
+		var candidates = section.querySelectorAll(
+			'.extrachill-blog-geographic-bridge-candidates'
+		);
+		if ( ! candidates.length ) {
+			return;
+		}
+
+		for ( var i = 0; i < candidates.length; i++ ) {
+			candidates[ i ].removeAttribute( 'hidden' );
+			candidates[ i ].removeAttribute( 'inert' );
+			candidates[ i ].removeAttribute( 'aria-hidden' );
+			candidates[ i ].style.display = 'contents';
+		}
+		section.removeAttribute( 'hidden' );
+	}
+
+	document.addEventListener( 'extrachill:experiment-assignment', function ( event ) {
+		var detail = event.detail || {};
+		if (
+			detail.experiment_key !== 'geo-bridge-holdout' ||
+			detail.surface !== 'single-post-bridge' ||
+			detail.variant !== 'treatment'
+		) {
+			return;
+		}
+
+		activate( event.target );
+	} );
+
+	var assigned = document.querySelectorAll(
+		'[data-ec-experiment-key="geo-bridge-holdout"]' +
+			'[data-ec-experiment-surface="single-post-bridge"]' +
+			'[data-ec-experiment-variant="treatment"]'
+	);
+	for ( var i = 0; i < assigned.length; i++ ) {
+		activate( assigned[ i ] );
+	}
+} )();

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
             "php tests/artist-activity.php",
             "php tests/newsletter-context.php",
             "php tests/network-bridge.php",
+            "node tests/geographic-bridge-experiment.js",
             "@lint:php"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
             "php tests/network-bridge.php",
             "php tests/artist-dispatch.php",
             "node tests/artist-dispatch-js.js",
+            "node tests/geographic-bridge-experiment.js",
             "@lint:php"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,15 @@
     "scripts": {
         "lint:php": "vendor/bin/phpcs --standard=WordPress *.php inc/",
         "lint:fix": "vendor/bin/phpcbf --standard=WordPress *.php inc/",
+        "test:integration": "bash tests/run-artist-dispatch-integration.sh",
         "test": [
             "php tests/homepage-event-markets.php",
             "php tests/festival-subscriptions.php",
             "php tests/artist-activity.php",
             "php tests/newsletter-context.php",
             "php tests/network-bridge.php",
+            "php tests/artist-dispatch.php",
+            "node tests/artist-dispatch-js.js",
             "@lint:php"
         ]
     },

--- a/docs/artist-dispatch-rollout.md
+++ b/docs/artist-dispatch-rollout.md
@@ -1,0 +1,17 @@
+# Artist Dispatch Rollout
+
+Deploying the plugin provisions editable native Page defaults at `/submit/`, `/submit/guidelines/`, and `/submit/write/` only when those paths do not already exist. Before enabling the pilot, an operator should review the page copy, configure and enable the Artist Dispatch policy in Extra Chill Users, and confirm Blocks Everywhere 3.6.0 or newer is active.
+
+Do not have plugin code rewrite the existing `/contribute/` page. During the content rollout, replace only its Writers paragraph with:
+
+> **Writers:** Active artists and music participants can build trust in the Extra Chill Community, then request access to submit a transparent first-person Artist Dispatch for editorial review. [Learn about the Artist Dispatch pathway](/submit/).
+
+The Developers, Software Testers, and Community Builders sections remain unchanged.
+
+## Editor Recovery Dependency
+
+Blocks Everywhere 3.6 mounts WordPress core's `LocalAutosaveMonitor`, but this integration has not proven a visible local-recovery notice or restore control in the embedded shell. This PR therefore promises native server autosave and real frontend preview only. Visible local recovery remains an upstream Blocks Everywhere requirement and must not be listed as launch acceptance until its UI is verified in an integrated browser test.
+
+## Integration Test
+
+`composer test:integration` drives the actual core posts and autosaves controllers in a disposable WordPress nightly sandbox. The script installs deterministic doubles for the public owner contracts, creates temporary users/posts, exercises the security boundaries, and cleans up. It must never run against production.

--- a/extrachill-blog.php
+++ b/extrachill-blog.php
@@ -32,6 +32,7 @@ require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/admin-customizations.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/ads-filter.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/home/homepage-hooks.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/power/power-page.php';
+require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/submit/artist-dispatch.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/blog-archive-routing.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/breadcrumbs.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/archive/festival-pillar.php';
@@ -88,6 +89,9 @@ add_action( 'wp_enqueue_scripts', 'extrachill_blog_register_styles', 5 );
 function extrachill_blog_activate() {
 	if ( function_exists( 'extrachill_blog_create_power_page' ) ) {
 		extrachill_blog_create_power_page();
+	}
+	if ( function_exists( 'extrachill_blog_provision_submit_pages' ) ) {
+		extrachill_blog_provision_submit_pages();
 	}
 
 	extrachill_blog_schedule_recently_shipped_refresh();

--- a/inc/single/network-bridge.php
+++ b/inc/single/network-bridge.php
@@ -23,11 +23,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Build the publication bridge configuration.
  *
+ * @param int $post_id Optional post ID. Defaults to the current post.
  * @return array Bridge configuration.
  */
-function extrachill_blog_network_bridge_args() {
+function extrachill_blog_network_bridge_args( $post_id = 0 ) {
 	return array(
-		'post_id'           => get_the_ID(),
+		'post_id'           => $post_id ? (int) $post_id : get_the_ID(),
 		'allowed_site_keys' => array( 'artist', 'events', 'wire', 'shop', 'community' ),
 		'slot_order'        => array( 'artist', 'events', 'wire', 'shop', 'community' ),
 		'utm_source'        => 'extrachill_blog',
@@ -36,6 +37,54 @@ function extrachill_blog_network_bridge_args() {
 		'heading_text'      => __( 'From Around the Extra Chill Network', 'extrachill-blog' ),
 	);
 }
+
+/**
+ * Register the browser activation script for geographic treatment cards.
+ */
+function extrachill_blog_register_geographic_bridge_script() {
+	$path = EXTRACHILL_BLOG_PLUGIN_DIR . 'assets/js/geographic-bridge-experiment.js';
+	if ( ! file_exists( $path ) ) {
+		return;
+	}
+
+	wp_register_script(
+		'extrachill-blog-geographic-bridge',
+		EXTRACHILL_BLOG_PLUGIN_URL . 'assets/js/geographic-bridge-experiment.js',
+		array( 'extrachill-experiment-assignment' ),
+		(string) filemtime( $path ),
+		array(
+			'strategy'  => 'defer',
+			'in_footer' => true,
+		)
+	);
+}
+add_action( 'wp_enqueue_scripts', 'extrachill_blog_register_geographic_bridge_script', 6 );
+
+/**
+ * Register the code-owned geographic bridge holdout.
+ *
+ * @param array $definitions Existing experiment definitions.
+ * @return array Experiment definitions.
+ */
+function extrachill_blog_register_bridge_experiment( $definitions ) {
+	if ( ! is_array( $definitions ) ) {
+		$definitions = array();
+	}
+
+	$definitions['geo-bridge-holdout'] = array(
+		'default_variant'      => 'control',
+		'control_variant'      => 'control',
+		'variants'             => array(
+			'control'   => 50,
+			'treatment' => 50,
+		),
+		'surfaces'             => array( 'single-post-bridge' ),
+		'eligibility_callback' => 'extrachill_blog_geographic_bridge_experiment_eligible',
+	);
+
+	return $definitions;
+}
+add_filter( 'extrachill_experiment_definitions', 'extrachill_blog_register_bridge_experiment' );
 
 /**
  * Resolve primary cards, then fill vacant geographic destination slots.
@@ -47,7 +96,7 @@ function extrachill_blog_network_bridge_args() {
  * @param array $args Bridge configuration.
  * @return array Ordered bridge cards.
  */
-function extrachill_blog_network_bridge_cards( $args ) {
+function extrachill_blog_network_bridge_card_groups( $args ) {
 	$primary_cards = extrachill_network_bridge_get_cards(
 		$args['post_id'],
 		array( 'artist', 'festival' ),
@@ -64,9 +113,10 @@ function extrachill_blog_network_bridge_cards( $args ) {
 		}
 	}
 
+	$geographic_cards = array();
 	$geographic_slots = array( 'events', 'community' );
 	if ( array_diff( $geographic_slots, array_keys( $by_site ) ) ) {
-		$geographic_cards = extrachill_network_bridge_get_cards(
+		$candidates = extrachill_network_bridge_get_cards(
 			$args['post_id'],
 			array( 'location', 'venue' ),
 			$geographic_slots,
@@ -75,11 +125,34 @@ function extrachill_blog_network_bridge_cards( $args ) {
 			$args['cache_prefix'] . 'geographic_'
 		);
 
-		foreach ( $geographic_cards as $card ) {
+		foreach ( $candidates as $card ) {
 			$site_key = isset( $card['site_key'] ) ? $card['site_key'] : '';
 			if ( in_array( $site_key, $geographic_slots, true ) && ! isset( $by_site[ $site_key ] ) ) {
-				$by_site[ $site_key ] = $card;
+				$geographic_cards[ $site_key ] = $card;
+				$by_site[ $site_key ]          = $card;
 			}
+		}
+	}
+
+	return array(
+		'primary'    => $primary_cards,
+		'geographic' => array_values( $geographic_cards ),
+	);
+}
+
+/**
+ * Resolve the complete treatment card set in canonical slot order.
+ *
+ * @param array $args Bridge configuration.
+ * @return array Ordered bridge cards.
+ */
+function extrachill_blog_network_bridge_cards( $args ) {
+	$groups  = extrachill_blog_network_bridge_card_groups( $args );
+	$by_site = array();
+
+	foreach ( array_merge( $groups['primary'], $groups['geographic'] ) as $card ) {
+		if ( ! empty( $card['site_key'] ) && ! isset( $by_site[ $card['site_key'] ] ) ) {
+			$by_site[ $card['site_key'] ] = $card;
 		}
 	}
 
@@ -91,6 +164,37 @@ function extrachill_blog_network_bridge_cards( $args ) {
 	}
 
 	return $cards;
+}
+
+/**
+ * Re-resolve whether a published post has vacant geographic bridge capacity.
+ *
+ * @param array  $context Assignment context.
+ * @param string $surface Requested experiment surface.
+ * @return bool Whether the post is eligible for geographic treatment.
+ */
+function extrachill_blog_geographic_bridge_experiment_eligible( $context, $surface ) {
+	if ( 'single-post-bridge' !== $surface
+		|| ! is_array( $context )
+		|| ! isset( $context['post_id'] )
+		|| ! is_scalar( $context['post_id'] )
+		|| ! function_exists( 'extrachill_network_bridge_get_cards' )
+		|| ! function_exists( 'get_post_type' )
+		|| ! function_exists( 'get_post_status' ) ) {
+		return false;
+	}
+
+	$post_id = (int) $context['post_id'];
+	if ( $post_id <= 0
+		|| (string) $post_id !== (string) $context['post_id']
+		|| 'post' !== get_post_type( $post_id )
+		|| 'publish' !== get_post_status( $post_id ) ) {
+		return false;
+	}
+
+	$groups = extrachill_blog_network_bridge_card_groups( extrachill_blog_network_bridge_args( $post_id ) );
+
+	return ! empty( $groups['geographic'] );
 }
 
 /**
@@ -110,19 +214,64 @@ function extrachill_blog_network_bridge() {
 		return;
 	}
 
-	$args  = extrachill_blog_network_bridge_args();
-	$cards = extrachill_blog_network_bridge_cards( $args );
-	if ( empty( $cards ) ) {
+	$args   = extrachill_blog_network_bridge_args();
+	$groups = extrachill_blog_network_bridge_card_groups( $args );
+	if ( empty( $groups['primary'] ) && empty( $groups['geographic'] ) ) {
 		return;
+	}
+
+	$experiment_attributes = '';
+	if ( ! empty( $groups['geographic'] )
+		&& function_exists( 'extrachill_experiment_attributes' )
+		&& function_exists( 'wp_script_is' )
+		&& wp_script_is( 'extrachill-experiment-assignment', 'registered' )
+		&& wp_script_is( 'extrachill-blog-geographic-bridge', 'registered' ) ) {
+		$experiment_attributes = extrachill_experiment_attributes(
+			'geo-bridge-holdout',
+			'single-post-bridge',
+			array( 'post_id' => $args['post_id'] )
+		);
+	}
+
+	if ( empty( $groups['primary'] ) && '' === $experiment_attributes ) {
+		return;
+	}
+
+	if ( '' !== $experiment_attributes ) {
+		wp_enqueue_script( 'extrachill-blog-geographic-bridge' );
+	} else {
+		$groups['geographic'] = array();
+	}
+
+	$cards_by_site    = array();
+	$geographic_sites = array();
+	foreach ( $groups['primary'] as $card ) {
+		if ( ! empty( $card['site_key'] ) ) {
+			$cards_by_site[ $card['site_key'] ] = $card;
+		}
+	}
+	foreach ( $groups['geographic'] as $card ) {
+		if ( ! empty( $card['site_key'] ) && ! isset( $cards_by_site[ $card['site_key'] ] ) ) {
+			$cards_by_site[ $card['site_key'] ]    = $card;
+			$geographic_sites[ $card['site_key'] ] = true;
+		}
 	}
 
 	wp_enqueue_style( 'extrachill-network-bridge' );
 	?>
-	<div class="network-bridge-section related-tax-section" aria-labelledby="<?php echo esc_attr( $args['heading_id'] ); ?>">
+	<div class="network-bridge-section related-tax-section" aria-labelledby="<?php echo esc_attr( $args['heading_id'] ); ?>" <?php echo $experiment_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Network returns fully escaped, cache-neutral attributes. ?><?php echo empty( $groups['primary'] ) ? ' hidden' : ''; ?>>
 		<h3 class="network-bridge-header related-tax-header" id="<?php echo esc_attr( $args['heading_id'] ); ?>"><?php echo esc_html( $args['heading_text'] ); ?></h3>
 		<div class="network-bridge-links ec-cross-site-links">
-			<?php foreach ( $cards as $card ) : ?>
-				<?php extrachill_cross_site_link_button( $card, 'network-bridge-link' ); ?>
+			<?php foreach ( $args['slot_order'] as $site_key ) : ?>
+				<?php if ( isset( $cards_by_site[ $site_key ] ) ) : ?>
+					<?php if ( isset( $geographic_sites[ $site_key ] ) ) : ?>
+						<span class="extrachill-blog-geographic-bridge-candidates" hidden inert aria-hidden="true">
+					<?php endif; ?>
+						<?php extrachill_cross_site_link_button( $cards_by_site[ $site_key ], 'network-bridge-link' ); ?>
+					<?php if ( isset( $geographic_sites[ $site_key ] ) ) : ?>
+						</span>
+					<?php endif; ?>
+				<?php endif; ?>
 			<?php endforeach; ?>
 		</div>
 	</div>

--- a/inc/submit/artist-dispatch.php
+++ b/inc/submit/artist-dispatch.php
@@ -1,0 +1,890 @@
+<?php
+/**
+ * Artist Dispatch submission pathway.
+ *
+ * WordPress owns posts, capabilities, autosaves, revisions, and previews.
+ * Extra Chill Users owns access and represented-artist authorization. Blocks
+ * Everywhere owns the canonical frontend editor shell.
+ *
+ * @package ExtraChillBlog
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const EXTRACHILL_BLOG_DISPATCH_SOURCE_META       = '_ec_artist_dispatch_source';
+const EXTRACHILL_BLOG_DISPATCH_SUBMITTER_META    = '_ec_artist_dispatch_submitter';
+const EXTRACHILL_BLOG_DISPATCH_ARTIST_META       = '_ec_artist_dispatch_artist';
+const EXTRACHILL_BLOG_DISPATCH_SUBMITTED_META    = '_ec_artist_dispatch_submitted_at';
+const EXTRACHILL_BLOG_DISPATCH_TERMS_META        = '_ec_artist_dispatch_terms_version';
+const EXTRACHILL_BLOG_DISPATCH_SOURCE            = 'artist-dispatch';
+const EXTRACHILL_BLOG_DISPATCH_TERMS_VERSION     = '2026-07-18';
+const EXTRACHILL_BLOG_DISPATCH_CATEGORY_SLUG     = 'artist-dispatch';
+const EXTRACHILL_BLOG_DISPATCH_MIN_BE_VERSION    = '3.6.0';
+const EXTRACHILL_BLOG_DISPATCH_DEFAULT_DRAFT_MAX = 3;
+const EXTRACHILL_BLOG_DISPATCH_DEFAULT_QUEUE_MAX = 2;
+const EXTRACHILL_BLOG_DISPATCH_ROLE              = 'extra_chill_artist_dispatch_contributor';
+const EXTRACHILL_BLOG_DISPATCH_CREATE_HEADER     = 'X-Extra-Chill-Artist-Dispatch';
+const EXTRACHILL_BLOG_DISPATCH_PAGES_OPTION      = 'extrachill_blog_artist_dispatch_pages';
+
+/** Feature-owned page definitions and exact stored sentinels. */
+const EXTRACHILL_BLOG_DISPATCH_PAGES = array(
+	'submit'            => array(
+		'title'    => 'Artist Dispatch',
+		'sentinel' => '<!-- extrachill-artist-dispatch -->',
+	),
+	'submit/guidelines' => array(
+		'title'    => 'Artist Dispatch Guidelines',
+		'sentinel' => '<!-- extrachill-artist-dispatch-guidelines -->',
+	),
+	'submit/write'      => array(
+		'title'    => 'Write an Artist Dispatch',
+		'sentinel' => '<!-- extrachill-artist-dispatch-editor -->',
+	),
+);
+
+/**
+ * Provision a native page without changing an existing page.
+ *
+ * @param string $path Path relative to the site root.
+ * @param string $title Page title.
+ * @param string $sentinel Stored content sentinel.
+ * @param int    $parent_id Parent page ID.
+ * @return int Page ID, or zero on failure.
+ */
+function extrachill_blog_provision_submit_page( $path, $title, $sentinel, $parent_id = 0 ) {
+	$existing = get_page_by_path( $path, OBJECT, 'page' );
+	if ( $existing ) {
+		$owned = (array) get_option( EXTRACHILL_BLOG_DISPATCH_PAGES_OPTION, array() );
+		return isset( $owned[ $path ] ) && (int) $owned[ $path ] === (int) $existing->ID && $sentinel === $existing->post_content
+			? (int) $existing->ID
+			: 0;
+	}
+
+	$page_id = wp_insert_post(
+		array(
+			'post_title'   => $title,
+			'post_name'    => basename( $path ),
+			'post_content' => $sentinel,
+			'post_status'  => 'draft',
+			'post_type'    => 'page',
+			'post_parent'  => $parent_id,
+		),
+		true
+	);
+
+	if ( is_wp_error( $page_id ) || ! $page_id ) {
+		return 0;
+	}
+	$owned          = (array) get_option( EXTRACHILL_BLOG_DISPATCH_PAGES_OPTION, array() );
+	$owned[ $path ] = (int) $page_id;
+	update_option( EXTRACHILL_BLOG_DISPATCH_PAGES_OPTION, $owned );
+	return (int) $page_id;
+}
+
+/**
+ * Provision /submit and its native child pages idempotently.
+ */
+function extrachill_blog_provision_submit_pages() {
+	$submit_id = extrachill_blog_provision_submit_page(
+		'submit',
+		EXTRACHILL_BLOG_DISPATCH_PAGES['submit']['title'],
+		EXTRACHILL_BLOG_DISPATCH_PAGES['submit']['sentinel']
+	);
+	if ( ! $submit_id ) {
+		return false;
+	}
+
+	$guidelines_id = extrachill_blog_provision_submit_page(
+		'submit/guidelines',
+		EXTRACHILL_BLOG_DISPATCH_PAGES['submit/guidelines']['title'],
+		EXTRACHILL_BLOG_DISPATCH_PAGES['submit/guidelines']['sentinel'],
+		$submit_id
+	);
+	if ( ! $guidelines_id ) {
+		return false;
+	}
+	$write_id = extrachill_blog_provision_submit_page(
+		'submit/write',
+		EXTRACHILL_BLOG_DISPATCH_PAGES['submit/write']['title'],
+		EXTRACHILL_BLOG_DISPATCH_PAGES['submit/write']['sentinel'],
+		$submit_id
+	);
+	return (bool) $write_id;
+}
+
+/**
+ * Run page provisioning once per plugin version.
+ */
+function extrachill_blog_maybe_provision_submit_pages() {
+	if ( version_compare( get_option( 'extrachill_blog_submit_page_version', '0' ), EXTRACHILL_BLOG_VERSION, '<' ) ) {
+		if ( extrachill_blog_provision_submit_pages() ) {
+			update_option( 'extrachill_blog_submit_page_version', EXTRACHILL_BLOG_VERSION );
+		}
+	}
+}
+add_action( 'admin_init', 'extrachill_blog_maybe_provision_submit_pages' );
+
+/**
+ * Read the exact Extra Chill Users self-access contract.
+ *
+ * The contract returns status, artist_id, and eligibility. Eligibility carries
+ * criteria, reasons, and the operator policy. Missing data fails closed.
+ *
+ * @return array|WP_Error Access state.
+ */
+function extrachill_blog_dispatch_access() {
+	if ( ! is_user_logged_in() || ! function_exists( 'wp_get_ability' ) ) {
+		return new WP_Error( 'artist_dispatch_logged_out', __( 'Please log in to continue.', 'extrachill-blog' ) );
+	}
+
+	$ability = wp_get_ability( 'extrachill/get-artist-dispatch-access' );
+	if ( ! $ability ) {
+		$result = new WP_Error( 'artist_dispatch_dependency_missing', __( 'Artist Dispatch access is temporarily unavailable.', 'extrachill-blog' ) );
+	} else {
+		$result = $ability->execute( array() );
+	}
+	$result = apply_filters( 'extrachill_blog_artist_dispatch_access_state', $result );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+	if ( ! is_array( $result ) || ! isset( $result['status'], $result['eligibility']['criteria'], $result['eligibility']['policy']['pilot_enabled'] ) ) {
+		return new WP_Error( 'artist_dispatch_invalid_contract', __( 'Artist Dispatch access is temporarily unavailable.', 'extrachill-blog' ) );
+	}
+
+	return $result;
+}
+
+/**
+ * Determine whether the current user has approved native write access.
+ *
+ * @param array|WP_Error|null $access Optional resolved access state.
+ * @return bool Whether access is approved.
+ */
+function extrachill_blog_dispatch_is_approved( $access = null ) {
+	$access = null === $access ? extrachill_blog_dispatch_access() : $access;
+	return ! is_wp_error( $access )
+		&& ! empty( $access['eligibility']['policy']['pilot_enabled'] )
+		&& 'approved' === $access['status']
+		&& current_user_can( 'edit_posts' )
+		&& current_user_can( 'submit_for_review' ); // phpcs:ignore WordPress.WP.Capabilities.Unknown -- registered by the required Extra Chill Users dependency.
+}
+
+/**
+ * Confirm the audited terms acceptance returned by Extra Chill Users.
+ *
+ * @param array|WP_Error $access Access state.
+ * @return bool Whether current terms were accepted in the audited request.
+ */
+function extrachill_blog_dispatch_has_current_terms( $access ) {
+	return ! is_wp_error( $access )
+		&& ! empty( $access['terms_acknowledged'] )
+		&& isset( $access['terms_version'] )
+		&& EXTRACHILL_BLOG_DISPATCH_TERMS_VERSION === $access['terms_version'];
+}
+
+/**
+ * Confirm an artist ID against the Users ability response.
+ *
+ * @param int        $artist_id Artist profile ID.
+ * @param array|null $access Access state.
+ * @return bool Whether the current user may represent the artist.
+ */
+function extrachill_blog_dispatch_can_represent_artist( $artist_id, $access = null ) {
+	$access = null === $access ? extrachill_blog_dispatch_access() : $access;
+	if ( is_wp_error( $access ) || ! extrachill_blog_dispatch_is_approved( $access ) ) {
+		return false;
+	}
+
+	$artist_id = absint( $artist_id );
+	if ( 0 >= $artist_id || absint( isset( $access['artist_id'] ) ? $access['artist_id'] : 0 ) !== $artist_id ) {
+		return false;
+	}
+
+	$artist_ids = isset( $access['eligibility']['criteria']['claimed_artist']['artist_ids'] )
+		? array_map( 'absint', (array) $access['eligibility']['criteria']['claimed_artist']['artist_ids'] )
+		: array();
+	return in_array( $artist_id, $artist_ids, true );
+}
+
+/**
+ * Check the deployed Blocks Everywhere dependency.
+ *
+ * @return bool Whether the canonical editor API is available.
+ */
+function extrachill_blog_dispatch_has_editor_dependency() {
+	return class_exists( '\\Automattic\\Blocks_Everywhere\\Blocks_Everywhere' )
+		&& version_compare( \Automattic\Blocks_Everywhere\Blocks_Everywhere::VERSION, EXTRACHILL_BLOG_DISPATCH_MIN_BE_VERSION, '>=' );
+}
+
+/**
+ * Test whether a post belongs to this intake pathway.
+ *
+ * @param int $post_id Post ID.
+ * @return bool Whether this is an Artist Dispatch.
+ */
+function extrachill_blog_is_artist_dispatch( $post_id ) {
+	return EXTRACHILL_BLOG_DISPATCH_SOURCE === get_post_meta( $post_id, EXTRACHILL_BLOG_DISPATCH_SOURCE_META, true );
+}
+
+/**
+ * Whether a user is an editorial reviewer.
+ *
+ * @param int $user_id User ID, or current user when omitted.
+ * @return bool Whether the user can edit others' posts.
+ */
+function extrachill_blog_dispatch_is_editor( $user_id = 0 ) {
+	$user_id = $user_id ? absint( $user_id ) : get_current_user_id();
+	return $user_id > 0 && user_can( $user_id, 'edit_others_posts' );
+}
+
+/**
+ * Whether edit_posts authority comes only from the dedicated Dispatch role.
+ *
+ * Users with an unrelated Author-style role retain their ordinary post lane;
+ * marked Dispatch writes still require current product approval separately.
+ *
+ * @param int $user_id User ID, or current user when omitted.
+ * @return bool Whether the product grant is the sole editing role.
+ */
+function extrachill_blog_dispatch_is_product_only_user( $user_id = 0 ) {
+	$user_id = $user_id ? absint( $user_id ) : get_current_user_id();
+	$user    = get_userdata( $user_id );
+	if ( ! $user || ! user_can( $user_id, 'submit_for_review' ) || extrachill_blog_dispatch_is_editor( $user_id ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown -- registered by Extra Chill Users.
+		return false;
+	}
+	foreach ( (array) $user->roles as $role_name ) {
+		if ( EXTRACHILL_BLOG_DISPATCH_ROLE === $role_name ) {
+			continue;
+		}
+		$role = get_role( $role_name );
+		if ( $role && ! empty( $role->capabilities['edit_posts'] ) ) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Get active post limits.
+ *
+ * @return array{draft:int,pending:int} Limits.
+ */
+function extrachill_blog_dispatch_limits() {
+	return array(
+		'draft'   => max( 1, (int) apply_filters( 'extrachill_blog_artist_dispatch_draft_limit', EXTRACHILL_BLOG_DISPATCH_DEFAULT_DRAFT_MAX ) ),
+		'pending' => max( 1, (int) apply_filters( 'extrachill_blog_artist_dispatch_pending_limit', EXTRACHILL_BLOG_DISPATCH_DEFAULT_QUEUE_MAX ) ),
+	);
+}
+
+/**
+ * Count the current user's marked posts in one status.
+ *
+ * @param string $status Post status.
+ * @param int    $exclude Optional post ID to exclude.
+ * @return int Count.
+ */
+function extrachill_blog_dispatch_count( $status, $exclude = 0 ) {
+	$query = new WP_Query(
+		array(
+			'post_type'      => 'post',
+			'post_status'    => $status,
+			'author'         => get_current_user_id(),
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'post__not_in'   => $exclude ? array( $exclude ) : array(),
+			'meta_key'       => EXTRACHILL_BLOG_DISPATCH_SOURCE_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- bounded author/status provenance query.
+			'meta_value'     => EXTRACHILL_BLOG_DISPATCH_SOURCE, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- bounded author/status provenance query.
+			'no_found_rows'  => false,
+		)
+	);
+	return (int) $query->found_posts;
+}
+
+/** Get the server-owned provenance keys. */
+function extrachill_blog_dispatch_provenance_keys() {
+	return array(
+		EXTRACHILL_BLOG_DISPATCH_SOURCE_META,
+		EXTRACHILL_BLOG_DISPATCH_SUBMITTER_META,
+		EXTRACHILL_BLOG_DISPATCH_ARTIST_META,
+		EXTRACHILL_BLOG_DISPATCH_SUBMITTED_META,
+		EXTRACHILL_BLOG_DISPATCH_TERMS_META,
+	);
+}
+
+/**
+ * Register provenance without exposing it through public REST responses.
+ */
+function extrachill_blog_dispatch_register_meta() {
+	$fields = array(
+		EXTRACHILL_BLOG_DISPATCH_SOURCE_META    => 'string',
+		EXTRACHILL_BLOG_DISPATCH_SUBMITTER_META => 'integer',
+		EXTRACHILL_BLOG_DISPATCH_ARTIST_META    => 'integer',
+		EXTRACHILL_BLOG_DISPATCH_SUBMITTED_META => 'string',
+		EXTRACHILL_BLOG_DISPATCH_TERMS_META     => 'string',
+	);
+
+	foreach ( $fields as $key => $type ) {
+		register_post_meta(
+			'post',
+			$key,
+			array(
+				'single'        => true,
+				'type'          => $type,
+				'show_in_rest'  => false,
+				'auth_callback' => '__return_false',
+			)
+		);
+	}
+}
+add_action( 'init', 'extrachill_blog_dispatch_register_meta' );
+
+/**
+ * Block direct provenance mutation; only this plugin's scoped writer may set it.
+ *
+ * @param mixed  $check Existing short-circuit value.
+ * @param int    $object_id Post ID.
+ * @param string $meta_key Meta key.
+ * @return mixed False for unauthorized provenance writes, original value otherwise.
+ */
+function extrachill_blog_dispatch_guard_provenance_meta( $check, $object_id, $meta_key ) {
+	if ( ! in_array( $meta_key, extrachill_blog_dispatch_provenance_keys(), true ) ) {
+		return $check;
+	}
+	$allowed = isset( $GLOBALS['extrachill_blog_dispatch_meta_write'] )
+		&& (int) $GLOBALS['extrachill_blog_dispatch_meta_write'] === (int) $object_id;
+	return $allowed ? $check : false;
+}
+add_filter( 'add_post_metadata', 'extrachill_blog_dispatch_guard_provenance_meta', 10, 3 );
+add_filter( 'update_post_metadata', 'extrachill_blog_dispatch_guard_provenance_meta', 10, 3 );
+add_filter( 'delete_post_metadata', 'extrachill_blog_dispatch_guard_provenance_meta', 10, 3 );
+
+/**
+ * Write one immutable provenance value from the trusted server path.
+ *
+ * @param int    $post_id Post ID.
+ * @param string $key Provenance key.
+ * @param mixed  $value Value.
+ */
+function extrachill_blog_dispatch_set_provenance( $post_id, $key, $value ) {
+	if ( ! in_array( $key, extrachill_blog_dispatch_provenance_keys(), true ) ) {
+		return;
+	}
+	$GLOBALS['extrachill_blog_dispatch_meta_write'] = (int) $post_id;
+	update_post_meta( $post_id, $key, $value );
+	unset( $GLOBALS['extrachill_blog_dispatch_meta_write'] );
+}
+
+/**
+ * Detect any attempt to send server-owned provenance through REST.
+ *
+ * @param WP_REST_Request $request Request.
+ * @return bool Whether provenance was supplied.
+ */
+function extrachill_blog_dispatch_request_has_provenance( $request ) {
+	$meta = $request->get_param( 'meta' );
+	if ( ! is_array( $meta ) ) {
+		return false;
+	}
+	return (bool) array_intersect( array_keys( $meta ), extrachill_blog_dispatch_provenance_keys() );
+}
+
+/**
+ * Normalize a core REST raw-field envelope to a string.
+ *
+ * @param mixed $value Raw string or {raw: string} envelope.
+ * @return string Normalized raw value.
+ */
+function extrachill_blog_dispatch_raw_value( $value ) {
+	if ( is_array( $value ) && array_key_exists( 'raw', $value ) ) {
+		$value = $value['raw'];
+	} elseif ( is_object( $value ) && isset( $value->raw ) ) {
+		$value = $value->raw;
+	}
+	return is_scalar( $value ) ? (string) $value : '';
+}
+
+/**
+ * Detect the core autosaves controller while it delegates to the posts controller.
+ *
+ * @param WP_REST_Request $request Request.
+ * @return bool Whether this is a core autosave write.
+ */
+function extrachill_blog_dispatch_is_autosave_request( $request ) {
+	if ( false !== strpos( $request->get_route(), '/autosaves' ) || ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) ) {
+		return true;
+	}
+	foreach ( debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 12 ) as $frame ) { // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- core controller delegation has no public request marker.
+		if ( isset( $frame['class'] ) && WP_REST_Autosaves_Controller::class === $frame['class'] ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Acquire an atomic, short per-user operation lock.
+ *
+ * WordPress add_option() is an atomic database insert even without persistent object
+ * cache, so parallel tabs cannot both pass count+write.
+ *
+ * @param string $operation Operation name.
+ * @param int    $user_id User ID.
+ * @return array|WP_Error Owned lock token or conflict.
+ */
+function extrachill_blog_dispatch_acquire_lock( $operation, $user_id ) {
+	$key     = 'ec_dispatch_lock_' . sanitize_key( $operation ) . '_' . absint( $user_id );
+	$lock    = array(
+		'token'   => wp_generate_uuid4(),
+		'expires' => time() + 15,
+		'key'     => $key,
+	);
+	$current = get_option( $key, array() );
+	if ( empty( $current ) && add_option( $key, $lock, '', false ) ) {
+		$GLOBALS['extrachill_blog_dispatch_locks'][ $key ] = $lock;
+		return $lock;
+	}
+	if ( is_array( $current ) && ! empty( $current['expires'] ) && (int) $current['expires'] < time() ) {
+		global $wpdb;
+		$owned = false;
+		if ( isset( $wpdb->options ) ) {
+			$owned = 1 === $wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->options} SET option_value = %s WHERE option_name = %s AND option_value = %s", maybe_serialize( $lock ), $key, maybe_serialize( $current ) ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- atomic compare-and-swap on one owned lock option.
+			wp_cache_delete( $key, 'options' );
+		} elseif ( get_option( $key ) === $current ) {
+			update_option( $key, $lock, false );
+			$owned = true;
+		}
+		if ( $owned ) {
+			$GLOBALS['extrachill_blog_dispatch_locks'][ $key ] = $lock;
+			return $lock;
+		}
+	}
+	return new WP_Error( 'artist_dispatch_write_in_progress', __( 'Another Artist Dispatch request is already in progress.', 'extrachill-blog' ), array( 'status' => 409 ) );
+}
+
+/**
+ * Release one atomic operation lock.
+ *
+ * @param array $lock Owned lock token.
+ */
+function extrachill_blog_dispatch_release_lock( $lock ) {
+	if ( ! is_array( $lock ) || empty( $lock['key'] ) || empty( $lock['token'] ) ) {
+		return;
+	}
+	$key     = $lock['key'];
+	$current = get_option( $key, array() );
+	if ( ! is_array( $current ) || ! hash_equals( (string) $lock['token'], (string) ( $current['token'] ?? '' ) ) ) {
+		unset( $GLOBALS['extrachill_blog_dispatch_locks'][ $key ] );
+		return;
+	}
+	global $wpdb;
+	if ( isset( $wpdb->options ) ) {
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name = %s AND option_value = %s", $key, maybe_serialize( $current ) ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- owner-token compare-and-delete.
+		wp_cache_delete( $key, 'options' );
+	} elseif ( get_option( $key ) === $current ) {
+		delete_option( $key );
+	}
+	unset( $GLOBALS['extrachill_blog_dispatch_locks'][ $key ] );
+}
+
+/** Release request locks if core exits before an after-insert hook. */
+function extrachill_blog_dispatch_release_request_locks() {
+	foreach ( isset( $GLOBALS['extrachill_blog_dispatch_locks'] ) ? (array) $GLOBALS['extrachill_blog_dispatch_locks'] : array() as $lock ) {
+		extrachill_blog_dispatch_release_lock( $lock );
+	}
+}
+add_action( 'shutdown', 'extrachill_blog_dispatch_release_request_locks' );
+
+/**
+ * Authorize exactly one low-level post insertion after REST validation.
+ *
+ * @param int   $post_id Existing post ID, or zero for create.
+ * @param array $context Trusted context.
+ */
+function extrachill_blog_dispatch_authorize_insert( $post_id, array $context ) {
+	$context['post_id']                                 = absint( $post_id );
+	$context['consumed']                                = false;
+	$GLOBALS['extrachill_blog_dispatch_insert_context'] = $context;
+}
+
+/**
+ * Constrain direct wp_insert_post/wp_update_post use for product-only users.
+ *
+ * Validated core REST writes install a one-use authorization context. wp-admin,
+ * direct PHP writes, and a second insertion in the same request fail closed.
+ *
+ * @param bool  $maybe_empty Core empty-content verdict.
+ * @param array $postarr Post data.
+ * @return bool Whether insertion must stop.
+ */
+function extrachill_blog_dispatch_gate_low_level_insert( $maybe_empty, $postarr ) {
+	if ( 'post' !== ( isset( $postarr['post_type'] ) ? $postarr['post_type'] : 'post' ) ) {
+		return $maybe_empty;
+	}
+	$post_id = isset( $postarr['ID'] ) ? absint( $postarr['ID'] ) : 0;
+	$context = isset( $GLOBALS['extrachill_blog_dispatch_insert_context'] ) ? $GLOBALS['extrachill_blog_dispatch_insert_context'] : array();
+	if ( $post_id && extrachill_blog_is_artist_dispatch( $post_id ) && ! extrachill_blog_dispatch_is_editor() ) {
+		if ( empty( $context ) || ! empty( $context['consumed'] ) || (int) $context['post_id'] !== $post_id ) {
+			return true;
+		}
+		$GLOBALS['extrachill_blog_dispatch_insert_context']['consumed'] = true;
+		return false;
+	}
+	if ( ! extrachill_blog_dispatch_is_product_only_user() ) {
+		return $maybe_empty;
+	}
+	if ( empty( $context ) || ! empty( $context['consumed'] ) || (int) $context['post_id'] !== $post_id ) {
+		return true;
+	}
+	$GLOBALS['extrachill_blog_dispatch_insert_context']['consumed'] = true;
+	return false;
+}
+add_filter( 'wp_insert_post_empty_content', 'extrachill_blog_dispatch_gate_low_level_insert', 10, 2 );
+
+/**
+ * Recursively validate the text-first block and embed policy.
+ *
+ * @param array $blocks Parsed blocks.
+ * @return true|WP_Error Validation result.
+ */
+function extrachill_blog_dispatch_validate_blocks( array $blocks ) {
+	$allowed = array( 'core/paragraph', 'core/heading', 'core/list', 'core/list-item', 'core/quote', 'core/separator', 'core/embed' );
+	$hosts   = array( 'youtube.com', 'www.youtube.com', 'youtu.be', 'vimeo.com', 'www.vimeo.com', 'soundcloud.com', 'www.soundcloud.com', 'open.spotify.com', 'bandcamp.com' );
+
+	foreach ( $blocks as $block ) {
+		$name = isset( $block['blockName'] ) ? $block['blockName'] : null;
+		if ( null === $name && '' !== trim( isset( $block['innerHTML'] ) ? $block['innerHTML'] : '' ) ) {
+			return new WP_Error( 'artist_dispatch_unstructured_content', __( 'Artist Dispatch content must use supported blocks.', 'extrachill-blog' ), array( 'status' => 400 ) );
+		}
+		if ( null !== $name && ! in_array( $name, $allowed, true ) ) {
+			return new WP_Error( 'artist_dispatch_disallowed_block', __( 'This draft contains a block that Artist Dispatch does not support.', 'extrachill-blog' ), array( 'status' => 400 ) );
+		}
+		if ( 'core/embed' === $name ) {
+			$url             = isset( $block['attrs']['url'] ) ? esc_url_raw( $block['attrs']['url'] ) : '';
+			$host            = strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) );
+			$host_is_allowed = in_array( $host, $hosts, true ) || ( strlen( $host ) > 9 && '.bandcamp.com' === substr( $host, -13 ) );
+			if ( ! $url || ! $host_is_allowed ) {
+				return new WP_Error( 'artist_dispatch_disallowed_embed', __( 'That embed provider is not supported.', 'extrachill-blog' ), array( 'status' => 400 ) );
+			}
+		}
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			$valid = extrachill_blog_dispatch_validate_blocks( $block['innerBlocks'] );
+			if ( is_wp_error( $valid ) ) {
+				return $valid;
+			}
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Enforce Artist Dispatch policy through the native posts controller.
+ *
+ * @param stdClass        $prepared_post Prepared post.
+ * @param WP_REST_Request $request REST request.
+ * @return stdClass|WP_Error Prepared post or error.
+ */
+function extrachill_blog_dispatch_rest_pre_insert( $prepared_post, $request ) {
+	$post_id     = absint( $request->get_param( 'id' ) );
+	$creating    = 0 === $post_id;
+	$marked      = $post_id > 0 && extrachill_blog_is_artist_dispatch( $post_id );
+	$is_editor   = extrachill_blog_dispatch_is_editor();
+	$is_create   = $creating && 'create' === $request->get_header( EXTRACHILL_BLOG_DISPATCH_CREATE_HEADER );
+	$is_autosave = extrachill_blog_dispatch_is_autosave_request( $request );
+	$is_autosave = (bool) apply_filters( 'extrachill_blog_artist_dispatch_is_autosave_request', $is_autosave, $request );
+
+	if ( extrachill_blog_dispatch_request_has_provenance( $request ) ) {
+		return new WP_Error( 'artist_dispatch_server_owned_provenance', __( 'Artist Dispatch provenance is server-owned.', 'extrachill-blog' ), array( 'status' => 400 ) );
+	}
+	if ( $creating && ! $is_create ) {
+		return extrachill_blog_dispatch_is_product_only_user()
+			? new WP_Error( 'artist_dispatch_creation_required', __( 'Use the Artist Dispatch dashboard to create a post.', 'extrachill-blog' ), array( 'status' => 403 ) )
+			: $prepared_post;
+	}
+	if ( ! $creating && ! $marked ) {
+		return extrachill_blog_dispatch_is_product_only_user()
+			? new WP_Error( 'artist_dispatch_unmarked_forbidden', __( 'This account can edit only validated Artist Dispatches.', 'extrachill-blog' ), array( 'status' => 403 ) )
+			: $prepared_post;
+	}
+	if ( ! is_user_logged_in() || ! current_user_can( 'edit_posts' ) ) {
+		return new WP_Error( 'artist_dispatch_forbidden', __( 'You cannot edit Artist Dispatches.', 'extrachill-blog' ), array( 'status' => 403 ) );
+	}
+
+	if ( $is_create ) {
+		$access = extrachill_blog_dispatch_access();
+		if ( is_wp_error( $access ) ) {
+			return $access;
+		}
+		$artist_id = absint( isset( $access['artist_id'] ) ? $access['artist_id'] : 0 );
+		if ( $is_editor || ! extrachill_blog_dispatch_is_approved( $access ) || ! extrachill_blog_dispatch_has_current_terms( $access ) || ! extrachill_blog_dispatch_can_represent_artist( $artist_id, $access ) ) {
+			return new WP_Error( 'artist_dispatch_invalid_access', __( 'Approved access, a represented artist, and current audited terms are required.', 'extrachill-blog' ), array( 'status' => 403 ) );
+		}
+		$lock = extrachill_blog_dispatch_acquire_lock( 'create', get_current_user_id() );
+		if ( is_wp_error( $lock ) ) {
+			return $lock;
+		}
+		if ( extrachill_blog_dispatch_count( 'draft' ) >= extrachill_blog_dispatch_limits()['draft'] ) {
+			extrachill_blog_dispatch_release_lock( $lock );
+			return new WP_Error( 'artist_dispatch_draft_limit', __( 'Finish or submit an existing draft before starting another.', 'extrachill-blog' ), array( 'status' => 429 ) );
+		}
+		$prepared_post->post_author = get_current_user_id();
+		$prepared_post->post_status = 'draft';
+		extrachill_blog_dispatch_authorize_insert(
+			0,
+			array(
+				'creating'  => true,
+				'artist_id' => $artist_id,
+				'terms'     => $access['terms_version'],
+				'lock'      => $lock,
+			)
+		);
+		return $prepared_post;
+	}
+
+	if ( $is_editor ) {
+		// Affiliation is required when the contributor enters pending review.
+		// Editors own the final immediate or scheduled publication decision.
+		return $prepared_post;
+	}
+	$access = extrachill_blog_dispatch_access();
+	$post   = get_post( $post_id );
+	if ( ! extrachill_blog_dispatch_is_approved( $access ) || ! extrachill_blog_dispatch_has_current_terms( $access ) || ! $post || get_current_user_id() !== (int) $post->post_author || 'draft' !== $post->post_status ) {
+		return new WP_Error( 'artist_dispatch_locked', __( 'Only a currently approved submitter can edit their draft Artist Dispatch.', 'extrachill-blog' ), array( 'status' => 403 ) );
+	}
+	if ( ! extrachill_blog_dispatch_can_represent_artist( get_post_meta( $post_id, EXTRACHILL_BLOG_DISPATCH_ARTIST_META, true ), $access ) ) {
+		return new WP_Error( 'artist_dispatch_artist_invalid', __( 'The represented artist relationship is no longer valid.', 'extrachill-blog' ), array( 'status' => 403 ) );
+	}
+	$status = isset( $prepared_post->post_status ) ? $prepared_post->post_status : $post->post_status;
+	if ( ! in_array( $status, array( 'draft', 'pending' ), true ) ) {
+		return new WP_Error( 'artist_dispatch_invalid_status', __( 'Artist Dispatches can only be saved or submitted for review.', 'extrachill-blog' ), array( 'status' => 403 ) );
+	}
+	if ( $is_autosave ) {
+		$allowed_autosave = array( 'id', 'title', 'content', 'excerpt', 'meta', 'context', '_locale' );
+		foreach ( array_keys( array_merge( $request->get_params(), $request->get_body_params() ) ) as $field ) {
+			if ( ! in_array( $field, $allowed_autosave, true ) ) {
+				return new WP_Error( 'artist_dispatch_forbidden_autosave_field', __( 'That field cannot be changed by an Artist Dispatch autosave.', 'extrachill-blog' ), array( 'status' => 400 ) );
+			}
+		}
+	} else {
+		foreach ( array( 'author', 'featured_media', 'slug', 'date', 'date_gmt', 'categories', 'tags', 'template', 'format', 'password', 'sticky' ) as $field ) {
+			if ( $request->has_param( $field ) ) {
+				return new WP_Error( 'artist_dispatch_forbidden_field', __( 'That post field is managed by the editorial team.', 'extrachill-blog' ), array( 'status' => 400 ) );
+			}
+		}
+	}
+	$effective_content = $request->has_param( 'content' )
+		? extrachill_blog_dispatch_raw_value( $request->get_param( 'content' ) )
+		: $post->post_content;
+	$valid             = extrachill_blog_dispatch_validate_blocks( parse_blocks( $effective_content ) );
+	if ( is_wp_error( $valid ) ) {
+		return $valid;
+	}
+	$lock = '';
+	if ( 'pending' === $status ) {
+		$lock = extrachill_blog_dispatch_acquire_lock( 'pending', get_current_user_id() );
+		if ( is_wp_error( $lock ) ) {
+			return $lock;
+		}
+		if ( extrachill_blog_dispatch_count( 'pending', $post_id ) >= extrachill_blog_dispatch_limits()['pending'] ) {
+			extrachill_blog_dispatch_release_lock( $lock );
+			return new WP_Error( 'artist_dispatch_pending_limit', __( 'Wait for an editor to review an existing submission before sending another.', 'extrachill-blog' ), array( 'status' => 429 ) );
+		}
+	}
+	extrachill_blog_dispatch_authorize_insert(
+		$post_id,
+		array(
+			'creating' => false,
+			'lock'     => $lock,
+		)
+	);
+	return $prepared_post;
+}
+add_filter( 'rest_pre_insert_post', 'extrachill_blog_dispatch_rest_pre_insert', 10, 2 );
+
+/**
+ * Reject protected autosave fields before the parent posts schema can act on them.
+ *
+ * The autosaves controller delegates preparation to the posts controller, whose
+ * broader schema includes fields that must never reach an unlocked author draft.
+ * Content and access policy still run through rest_pre_insert_post.
+ *
+ * @param mixed           $result Pre-dispatch result.
+ * @param WP_REST_Server  $server REST server.
+ * @param WP_REST_Request $request Request.
+ * @return mixed|WP_Error Original result or field error.
+ */
+function extrachill_blog_dispatch_guard_autosave_fields( $result, $server, $request ) {
+	unset( $server );
+	if ( null !== $result || ! preg_match( '#^/wp/v2/posts/(?P<id>\d+)/autosaves$#', $request->get_route(), $matches ) || ! extrachill_blog_is_artist_dispatch( absint( $matches['id'] ) ) ) {
+		return $result;
+	}
+	$allowed = array( 'id', 'title', 'content', 'excerpt', 'meta', 'context', '_locale' );
+	foreach ( array_keys( array_merge( $request->get_params(), $request->get_body_params() ) ) as $field ) {
+		if ( ! in_array( $field, $allowed, true ) ) {
+			return new WP_Error( 'artist_dispatch_forbidden_autosave_field', __( 'That field cannot be changed by an Artist Dispatch autosave.', 'extrachill-blog' ), array( 'status' => 400 ) );
+		}
+	}
+	return $result;
+}
+add_filter( 'rest_pre_dispatch', 'extrachill_blog_dispatch_guard_autosave_fields', 10, 3 );
+
+/**
+ * Stamp trusted provenance after native draft creation.
+ *
+ * @param WP_Post         $post Inserted post.
+ * @param WP_REST_Request $request REST request.
+ * @param bool            $creating Whether the post was created.
+ */
+function extrachill_blog_dispatch_rest_after_insert( $post, $request, $creating ) {
+	unset( $request );
+	$context = isset( $GLOBALS['extrachill_blog_dispatch_insert_context'] ) ? $GLOBALS['extrachill_blog_dispatch_insert_context'] : array();
+	if ( $creating && ! empty( $context['creating'] ) && ! empty( $context['consumed'] ) ) {
+		extrachill_blog_dispatch_set_provenance( $post->ID, EXTRACHILL_BLOG_DISPATCH_SOURCE_META, EXTRACHILL_BLOG_DISPATCH_SOURCE );
+		extrachill_blog_dispatch_set_provenance( $post->ID, EXTRACHILL_BLOG_DISPATCH_SUBMITTER_META, get_current_user_id() );
+		extrachill_blog_dispatch_set_provenance( $post->ID, EXTRACHILL_BLOG_DISPATCH_ARTIST_META, absint( $context['artist_id'] ) );
+		extrachill_blog_dispatch_set_provenance( $post->ID, EXTRACHILL_BLOG_DISPATCH_TERMS_META, sanitize_text_field( $context['terms'] ) );
+		extrachill_blog_dispatch_ensure_category( $post->ID );
+		extrachill_blog_dispatch_emit_event( 'draft_created', $post->ID );
+	}
+	if ( ! empty( $context['lock'] ) ) {
+		extrachill_blog_dispatch_release_lock( $context['lock'] );
+	}
+	unset( $GLOBALS['extrachill_blog_dispatch_insert_context'] );
+}
+add_action( 'rest_after_insert_post', 'extrachill_blog_dispatch_rest_after_insert', 10, 3 );
+
+/**
+ * Lock contributor access to pending and published Dispatches in native caps.
+ *
+ * @param string[] $caps Primitive capabilities.
+ * @param string   $cap Requested capability.
+ * @param int      $user_id User ID.
+ * @param array    $args Capability arguments.
+ * @return string[] Filtered capabilities.
+ */
+function extrachill_blog_dispatch_map_meta_cap( $caps, $cap, $user_id, $args ) {
+	if ( ! in_array( $cap, array( 'edit_post', 'delete_post', 'read_post' ), true ) || empty( $args[0] ) ) {
+		return $caps;
+	}
+	$post = get_post( absint( $args[0] ) );
+	if ( ! $post || ! extrachill_blog_is_artist_dispatch( $post->ID ) || extrachill_blog_dispatch_is_editor( $user_id ) ) {
+		return $caps;
+	}
+	$submitter = absint( get_post_meta( $post->ID, EXTRACHILL_BLOG_DISPATCH_SUBMITTER_META, true ) );
+	if ( 'read_post' === $cap ) {
+		return 'publish' === $post->post_status || $submitter === (int) $user_id ? $caps : array( 'do_not_allow' );
+	}
+	if ( $submitter !== (int) $user_id || 'draft' !== $post->post_status ) {
+		return array( 'do_not_allow' );
+	}
+	if ( get_current_user_id() !== (int) $user_id || ! extrachill_blog_dispatch_is_approved() ) {
+		return array( 'do_not_allow' );
+	}
+	return $caps;
+}
+add_filter( 'map_meta_cap', 'extrachill_blog_dispatch_map_meta_cap', 10, 4 );
+
+/**
+ * Stamp the first review time and lifecycle analytics.
+ *
+ * @param string  $new_status New status.
+ * @param string  $old_status Old status.
+ * @param WP_Post $post Post.
+ */
+function extrachill_blog_dispatch_transition( $new_status, $old_status, $post ) {
+	if ( ! $post instanceof WP_Post || ! extrachill_blog_is_artist_dispatch( $post->ID ) || $new_status === $old_status || get_post_status( $post->ID ) !== $new_status ) {
+		return;
+	}
+	if ( 'pending' === $new_status && 'draft' === $old_status ) {
+		if ( ! get_post_meta( $post->ID, EXTRACHILL_BLOG_DISPATCH_SUBMITTED_META, true ) ) {
+			extrachill_blog_dispatch_set_provenance( $post->ID, EXTRACHILL_BLOG_DISPATCH_SUBMITTED_META, current_time( 'mysql', true ) );
+		}
+		extrachill_blog_dispatch_emit_event( 'submitted', $post->ID );
+	}
+	if ( 'publish' === $new_status && 'publish' !== $old_status ) {
+		extrachill_blog_dispatch_ensure_category( $post->ID );
+		extrachill_blog_dispatch_emit_event( 'published', $post->ID );
+	}
+}
+add_action( 'transition_post_status', 'extrachill_blog_dispatch_transition', 10, 3 );
+
+/**
+ * Resolve lifecycle event names at one replaceable analytics boundary.
+ *
+ * @param string $event Lifecycle key.
+ * @return string Event name.
+ */
+function extrachill_blog_dispatch_event_name( $event ) {
+	$events = array(
+		'draft_created' => defined( 'EC_ANALYTICS_EVENT_ARTIST_DISPATCH_DRAFT_CREATED' ) ? EC_ANALYTICS_EVENT_ARTIST_DISPATCH_DRAFT_CREATED : '',
+		'submitted'     => defined( 'EC_ANALYTICS_EVENT_ARTIST_DISPATCH_SUBMITTED' ) ? EC_ANALYTICS_EVENT_ARTIST_DISPATCH_SUBMITTED : '',
+		'published'     => defined( 'EC_ANALYTICS_EVENT_ARTIST_DISPATCH_PUBLISHED' ) ? EC_ANALYTICS_EVENT_ARTIST_DISPATCH_PUBLISHED : '',
+	);
+	return isset( $events[ $event ] ) ? $events[ $event ] : '';
+}
+
+/**
+ * Emit a bounded lifecycle event through the analytics ability.
+ *
+ * @param string $event Lifecycle key.
+ * @param int    $post_id Optional post ID.
+ */
+function extrachill_blog_dispatch_emit_event( $event, $post_id = 0 ) {
+	$name    = extrachill_blog_dispatch_event_name( $event );
+	$ability = $name && function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/track-analytics-event' ) : null;
+	if ( ! $ability ) {
+		return;
+	}
+	$data = array(
+		'post_id'           => absint( $post_id ),
+		'submitter_user_id' => absint( get_post_meta( $post_id, EXTRACHILL_BLOG_DISPATCH_SUBMITTER_META, true ) ),
+		'artist_id'         => absint( get_post_meta( $post_id, EXTRACHILL_BLOG_DISPATCH_ARTIST_META, true ) ),
+	);
+	$ability->execute(
+		array(
+			'event_type' => $name,
+			'event_data' => $data,
+		)
+	);
+}
+
+/**
+ * Ensure the native Artist Dispatch category is assigned.
+ *
+ * @param int $post_id Post ID.
+ */
+function extrachill_blog_dispatch_ensure_category( $post_id ) {
+	$term = get_term_by( 'slug', EXTRACHILL_BLOG_DISPATCH_CATEGORY_SLUG, 'category' );
+	if ( ! $term ) {
+		$created = wp_insert_term( __( 'Artist Dispatch', 'extrachill-blog' ), 'category', array( 'slug' => EXTRACHILL_BLOG_DISPATCH_CATEGORY_SLUG ) );
+		if ( is_wp_error( $created ) ) {
+			return;
+		}
+		$term_id = (int) $created['term_id'];
+	} else {
+		$term_id = (int) $term->term_id;
+	}
+	wp_set_post_categories( $post_id, array( $term_id ), true );
+}
+
+/**
+ * Register the generic publication notification descriptor.
+ */
+function extrachill_blog_dispatch_register_notification() {
+	if ( function_exists( 'ec_users_register_publish_notify_source' ) ) {
+		ec_users_register_publish_notify_source(
+			'artist-dispatch',
+			array(
+				'meta_key'       => EXTRACHILL_BLOG_DISPATCH_SUBMITTER_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- notification descriptor, not a query.
+				'user_id_field'  => '',
+				'type'           => 'artist_dispatch_published',
+				/* translators: %s: published post title. */
+				'title_template' => __( 'Your Artist Dispatch “%s” is live', 'extrachill-blog' ),
+			)
+		);
+	}
+}
+add_action( 'init', 'extrachill_blog_dispatch_register_notification', 20 );
+
+require_once __DIR__ . '/pages.php';
+require_once __DIR__ . '/presentation.php';

--- a/inc/submit/pages.php
+++ b/inc/submit/pages.php
@@ -1,0 +1,451 @@
+<?php
+/**
+ * Native page rendering and Blocks Everywhere host integration.
+ *
+ * @package ExtraChillBlog
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Match a native page by its full hierarchical path.
+ *
+ * WordPress is_page() compares slugs, not a child page's full path, so using "write"
+ * alone could collide with an unrelated page elsewhere in the hierarchy.
+ *
+ * @param string $path Page path.
+ * @return bool Whether the current queried page is the path.
+ */
+function extrachill_blog_dispatch_is_page( $path ) {
+	if ( ! is_page() || ! isset( EXTRACHILL_BLOG_DISPATCH_PAGES[ $path ] ) ) {
+		return false;
+	}
+	$current = get_queried_object();
+	$owned   = (array) get_option( EXTRACHILL_BLOG_DISPATCH_PAGES_OPTION, array() );
+	return $current instanceof WP_Post
+		&& isset( $owned[ $path ] )
+		&& (int) $current->ID === (int) $owned[ $path ]
+		&& EXTRACHILL_BLOG_DISPATCH_PAGES[ $path ]['sentinel'] === $current->post_content;
+}
+
+/**
+ * Resolve and authorize the requested canonical draft without leaking it.
+ *
+ * @return WP_Post|WP_Error Authorized post or generic error.
+ */
+function extrachill_blog_dispatch_editor_post() {
+	static $resolved = null;
+	if ( null !== $resolved ) {
+		return $resolved;
+	}
+
+	$post_id = isset( $_GET['post'] ) ? absint( wp_unslash( $_GET['post'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only route selector; authorization follows.
+	if ( ! is_user_logged_in() ) {
+		$resolved = new WP_Error( 'artist_dispatch_login_required', __( 'Please log in to write an Artist Dispatch.', 'extrachill-blog' ), array( 'status' => 403 ) );
+		return $resolved;
+	}
+	if ( ! $post_id ) {
+		$resolved = new WP_Error( 'artist_dispatch_not_found', __( 'That Artist Dispatch draft is unavailable.', 'extrachill-blog' ), array( 'status' => 404 ) );
+		return $resolved;
+	}
+
+	$post      = get_post( $post_id );
+	$submitter = $post ? absint( get_post_meta( $post_id, EXTRACHILL_BLOG_DISPATCH_SUBMITTER_META, true ) ) : 0;
+	if ( ! $post || 'post' !== $post->post_type || ! extrachill_blog_is_artist_dispatch( $post_id ) || get_current_user_id() !== $submitter ) {
+		$resolved = new WP_Error( 'artist_dispatch_not_found', __( 'That Artist Dispatch draft is unavailable.', 'extrachill-blog' ), array( 'status' => 404 ) );
+		return $resolved;
+	}
+	$access = extrachill_blog_dispatch_access();
+	if ( 'draft' !== $post->post_status || ! current_user_can( 'edit_post', $post_id ) || ! extrachill_blog_dispatch_is_approved( $access ) || ! extrachill_blog_dispatch_has_current_terms( $access ) ) {
+		$resolved = new WP_Error( 'artist_dispatch_locked', __( 'This Artist Dispatch is not available for editing.', 'extrachill-blog' ), array( 'status' => 403 ) );
+		return $resolved;
+	}
+
+	$resolved = $post;
+	return $resolved;
+}
+
+/**
+ * Protect the editor page before any private markup or assets render.
+ */
+function extrachill_blog_dispatch_protect_editor() {
+	if ( ! extrachill_blog_dispatch_is_page( 'submit/write' ) ) {
+		return;
+	}
+	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+		define( 'DONOTCACHEPAGE', true );
+	}
+	nocache_headers();
+
+	$post = extrachill_blog_dispatch_editor_post();
+	if ( is_wp_error( $post ) ) {
+		$status = (int) $post->get_error_data()['status'];
+		wp_die( esc_html( $post->get_error_message() ), esc_html__( 'Artist Dispatch unavailable', 'extrachill-blog' ), array( 'response' => $status ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- integer response code, not output.
+	}
+	if ( ! extrachill_blog_dispatch_has_editor_dependency() ) {
+		wp_die(
+			esc_html__( 'The writing editor is temporarily unavailable. An administrator must activate Blocks Everywhere 3.6.0 or newer.', 'extrachill-blog' ),
+			esc_html__( 'Editor dependency unavailable', 'extrachill-blog' ),
+			array( 'response' => 503 )
+		);
+	}
+}
+add_action( 'template_redirect', 'extrachill_blog_dispatch_protect_editor', 1 );
+
+/**
+ * Register the Artist Dispatch editor as a Blocks Everywhere context.
+ *
+ * @param array $contexts Registered contexts.
+ * @return array Contexts.
+ */
+function extrachill_blog_dispatch_editor_context( $contexts ) {
+	$contexts['artist-dispatch'] = array(
+		'type'              => 'artist-dispatch',
+		'textarea'          => '#artist-dispatch-content',
+		'container'         => '.artist-dispatch-editor',
+		'trigger'           => 'wp_enqueue_scripts',
+		'trigger_priority'  => 20,
+		'condition'         => function () {
+			return extrachill_blog_dispatch_is_page( 'submit/write' ) && extrachill_blog_dispatch_editor_post() instanceof WP_Post;
+		},
+		'oembed_permission' => function () {
+			return extrachill_blog_dispatch_editor_post() instanceof WP_Post;
+		},
+		'settings_provider' => function ( $settings ) {
+			$post = extrachill_blog_dispatch_editor_post();
+			if ( ! $post instanceof WP_Post ) {
+				return $settings;
+			}
+			$settings['postEntity'] = array(
+				'type' => 'post',
+				'id'   => (int) $post->ID,
+			);
+			$settings['editor']['hasUploadPermissions'] = false;
+			$settings['blocksEverywhere']['blocks']['allowBlocks'] = array( 'core/paragraph', 'core/heading', 'core/list', 'core/list-item', 'core/quote', 'core/separator', 'core/embed' );
+			$settings['blocksEverywhere']['allowEmbeds'] = array( 'youtube', 'vimeo', 'soundcloud', 'spotify', 'bandcamp' );
+			$settings['blocksEverywhere']['chrome'] = array(
+				'mode'    => 'full-height',
+				'topBar'  => true,
+				'preview' => true,
+				'footer'  => true,
+			);
+			$settings['blocksEverywhere']['sidebar'] = array(
+				'inserter'  => true,
+				'inspector' => false,
+			);
+			$settings['blocksEverywhere']['settingsKey'] = 'artist-dispatch';
+			return $settings;
+		},
+		'preload_paths'     => function ( $paths ) {
+			$post = extrachill_blog_dispatch_editor_post();
+			if ( $post instanceof WP_Post ) {
+				$paths[] = '/wp/v2/posts/' . $post->ID . '?context=edit';
+				$paths[] = '/wp/v2/posts/' . $post->ID . '/autosaves?context=edit';
+			}
+			return array_values( array_unique( $paths ) );
+		},
+	);
+	return $contexts;
+}
+add_filter( 'blocks_everywhere_contexts', 'extrachill_blog_dispatch_editor_context' );
+
+/**
+ * Enqueue assets on the three submission pages.
+ */
+function extrachill_blog_dispatch_enqueue_assets() {
+	if ( ! extrachill_blog_dispatch_is_page( 'submit' ) && ! extrachill_blog_dispatch_is_page( 'submit/guidelines' ) && ! extrachill_blog_dispatch_is_page( 'submit/write' ) ) {
+		return;
+	}
+	$css = EXTRACHILL_BLOG_PLUGIN_DIR . 'assets/css/artist-dispatch.css';
+	wp_enqueue_style( 'extrachill-blog-artist-dispatch', EXTRACHILL_BLOG_PLUGIN_URL . 'assets/css/artist-dispatch.css', array( 'extrachill-root' ), filemtime( $css ) );
+
+	if ( extrachill_blog_dispatch_is_page( 'submit' ) && is_user_logged_in() ) {
+		$js = EXTRACHILL_BLOG_PLUGIN_DIR . 'assets/js/artist-dispatch.js';
+		wp_enqueue_script( 'extrachill-blog-artist-dispatch', EXTRACHILL_BLOG_PLUGIN_URL . 'assets/js/artist-dispatch.js', array( 'wp-api-fetch' ), filemtime( $js ), true );
+		wp_localize_script(
+			'extrachill-blog-artist-dispatch',
+			'ecArtistDispatch',
+			array(
+				'nonce'        => wp_create_nonce( 'wp_rest' ),
+				'restRoot'     => esc_url_raw( rest_url() ),
+				'writeUrl'     => home_url( '/submit/write/' ),
+				'termsVersion' => EXTRACHILL_BLOG_DISPATCH_TERMS_VERSION,
+			)
+		);
+	}
+
+	if ( extrachill_blog_dispatch_is_page( 'submit/write' ) && extrachill_blog_dispatch_editor_post() instanceof WP_Post ) {
+		$js = EXTRACHILL_BLOG_PLUGIN_DIR . 'assets/js/artist-dispatch-editor.js';
+		wp_enqueue_script( 'extrachill-blog-artist-dispatch-editor', EXTRACHILL_BLOG_PLUGIN_URL . 'assets/js/artist-dispatch-editor.js', array( 'blocks-everywhere', 'wp-components', 'wp-data', 'wp-editor', 'wp-element', 'wp-i18n' ), filemtime( $js ), true );
+		wp_localize_script( 'extrachill-blog-artist-dispatch-editor', 'ecArtistDispatchEditor', array( 'dashboardUrl' => home_url( '/submit/' ) ) );
+	}
+}
+add_action( 'wp_enqueue_scripts', 'extrachill_blog_dispatch_enqueue_assets', 30 );
+
+/**
+ * Render the public Artist Dispatch introduction.
+ *
+ * @return string HTML.
+ */
+function extrachill_blog_dispatch_intro_html() {
+	return '<header class="artist-dispatch-hero"><p class="artist-dispatch-kicker">' . esc_html__( 'From the people making the music', 'extrachill-blog' ) . '</p><h1>' . esc_html__( 'Artist Dispatch', 'extrachill-blog' ) . '</h1><p>' . esc_html__( 'Tell the real story behind your music in your own voice, with Extra Chill editorial review and a permanent main-site byline.', 'extrachill-blog' ) . '</p></header><section class="artist-dispatch-panel"><h2>' . esc_html__( 'A publication lane, not a promo form', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Forum posting is open to the community. Artist Dispatch is a scarce pathway into the Extra Chill publication for transparent first-person release stories, studio diaries, tour journals, scene reports, production breakdowns, and lessons from independent music work.', 'extrachill-blog' ) . '</p><p>' . esc_html__( 'It is not self-publishing, freelance hiring, a review of yourself, fake third-person reporting, or a place to paste a press release. Every Dispatch is reviewed by an editor before publication.', 'extrachill-blog' ) . '</p><a class="button-2" href="' . esc_url( home_url( '/submit/guidelines/' ) ) . '">' . esc_html__( 'Read the guidelines', 'extrachill-blog' ) . '</a></section>';
+}
+
+/**
+ * Render logged-out state without nonce or personalized data.
+ *
+ * @return string HTML.
+ */
+function extrachill_blog_dispatch_logged_out_html() {
+	$login = wp_login_url( home_url( '/submit/' ) );
+	$join  = function_exists( 'ec_get_site_url' ) ? trailingslashit( ec_get_site_url( 'community' ) ) . 'join/' : 'https://community.extrachill.com/join/';
+	return '<section class="artist-dispatch-state"><h2>' . esc_html__( 'Build your voice in the community', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Log in to check your Artist Dispatch eligibility, or join the community and start participating in the online music scene.', 'extrachill-blog' ) . '</p><div class="artist-dispatch-actions"><a class="button-1" href="' . esc_url( $login ) . '">' . esc_html__( 'Log in', 'extrachill-blog' ) . '</a><a class="button-2" href="' . esc_url( $join ) . '">' . esc_html__( 'Join the community', 'extrachill-blog' ) . '</a></div></section>';
+}
+
+/**
+ * Render eligibility criteria from the owner contract.
+ *
+ * @param array $eligibility Eligibility state.
+ * @return string HTML.
+ */
+function extrachill_blog_dispatch_criteria_html( $eligibility ) {
+	$criteria = isset( $eligibility['criteria'] ) && is_array( $eligibility['criteria'] ) ? $eligibility['criteria'] : array();
+	if ( empty( $criteria ) ) {
+		return '';
+	}
+	$html   = '<ul class="artist-dispatch-criteria">';
+	$labels = array(
+		'policy_configured' => __( 'Pilot policy configured', 'extrachill-blog' ),
+		'pilot_enabled'     => __( 'Pilot accepting requests', 'extrachill-blog' ),
+		'points'            => __( 'Community participation', 'extrachill-blog' ),
+		'onboarding'        => __( 'Profile and onboarding complete', 'extrachill-blog' ),
+		'account_age'       => __( 'Minimum account age', 'extrachill-blog' ),
+		'claimed_account'   => __( 'Claimed account', 'extrachill-blog' ),
+		'active_moderation' => __( 'Good moderation standing', 'extrachill-blog' ),
+		'claimed_artist'    => __( 'Claimed or managed artist', 'extrachill-blog' ),
+	);
+	foreach ( $criteria as $key => $criterion ) {
+		if ( ! is_array( $criterion ) || ! isset( $labels[ $key ] ) ) {
+			continue;
+		}
+		$html .= '<li class="' . ( ! empty( $criterion['passed'] ) ? 'is-met' : 'is-unmet' ) . '"><strong>' . esc_html( $labels[ $key ] ) . '</strong></li>';
+	}
+	foreach ( isset( $eligibility['reasons'] ) ? (array) $eligibility['reasons'] : array() as $reason ) {
+		$html .= '<li class="is-unmet"><span>' . esc_html( $reason ) . '</span></li>';
+	}
+	return $html . '</ul>';
+}
+
+/**
+ * Resolve safe represented-artist IDs from the Users owner contract.
+ *
+ * @param array $access Access state.
+ * @return array<int,array{name:string,url:string}> Artist display data keyed by ID.
+ */
+function extrachill_blog_dispatch_access_artists( $access ) {
+	$artist_ids = isset( $access['eligibility']['criteria']['claimed_artist']['artist_ids'] )
+		? array_map( 'absint', (array) $access['eligibility']['criteria']['claimed_artist']['artist_ids'] )
+		: array();
+	$artists    = array();
+	foreach ( $artist_ids as $artist_id ) {
+		$display = extrachill_blog_dispatch_artist_display( $artist_id );
+		if ( ! empty( $display ) ) {
+			$artists[ $artist_id ] = $display;
+		}
+	}
+	return $artists;
+}
+
+/**
+ * Render the access request form from canonical represented artists.
+ *
+ * @param array $access Access state.
+ * @return string HTML.
+ */
+function extrachill_blog_dispatch_request_html( $access ) {
+	$artists = extrachill_blog_dispatch_access_artists( $access );
+	$options = '';
+	foreach ( $artists as $artist_id => $artist ) {
+		$options .= '<option value="' . esc_attr( $artist_id ) . '">' . esc_html( $artist['name'] ) . '</option>';
+	}
+	if ( '' === $options ) {
+		return '<section class="artist-dispatch-state is-closed"><h2>' . esc_html__( 'A represented artist is required', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Connect your account to a canonical Artist Platform profile before requesting Artist Dispatch access.', 'extrachill-blog' ) . '</p></section>';
+	}
+
+	/* translators: %s: Artist Dispatch guidelines URL. */
+	$acknowledgement = sprintf( wp_kses_post( __( 'I have read the <a href="%s">Artist Dispatch guidelines</a>, disclosed my relationship to the project, and accept the rights and editorial terms.', 'extrachill-blog' ) ), esc_url( home_url( '/submit/guidelines/' ) ) );
+	return '<section class="artist-dispatch-state"><h2>' . esc_html__( 'Request Artist Dispatch access', 'extrachill-blog' ) . '</h2><form id="artist-dispatch-request" class="artist-dispatch-form"><label>' . esc_html__( 'Artist or project you represent', 'extrachill-blog' ) . '<select name="artist_id" required>' . $options . '</select></label><label>' . esc_html__( 'What story do you want to tell?', 'extrachill-blog' ) . '<textarea name="description" minlength="50" maxlength="2000" required></textarea></label><label>' . esc_html__( 'Optional sample or reference URL', 'extrachill-blog' ) . '<input type="url" name="sample_url"></label><label class="artist-dispatch-check"><input type="checkbox" name="acknowledgement" required><span>' . $acknowledgement . '</span></label><button class="button-1" type="submit">' . esc_html__( 'Request access', 'extrachill-blog' ) . '</button><p class="artist-dispatch-message" aria-live="polite"></p></form></section>';
+}
+
+/**
+ * Query the approved contributor's own marked posts.
+ *
+ * @return array<string,WP_Post[]> Posts by status.
+ */
+function extrachill_blog_dispatch_dashboard_posts() {
+	$groups = array(
+		'draft'   => array(),
+		'pending' => array(),
+		'publish' => array(),
+	);
+	$query  = new WP_Query(
+		array(
+			'post_type'      => 'post',
+			'post_status'    => array_keys( $groups ),
+			'author'         => get_current_user_id(),
+			'posts_per_page' => 50,
+			'orderby'        => 'modified',
+			'order'          => 'DESC',
+			'meta_key'       => EXTRACHILL_BLOG_DISPATCH_SOURCE_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- bounded current-author dashboard.
+			'meta_value'     => EXTRACHILL_BLOG_DISPATCH_SOURCE, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- bounded current-author dashboard.
+		)
+	);
+	foreach ( $query->posts as $post ) {
+		$groups[ $post->post_status ][] = $post;
+	}
+	return $groups;
+}
+
+/**
+ * Render one dashboard group.
+ *
+ * @param string    $title Group title.
+ * @param WP_Post[] $posts Posts.
+ * @param bool      $editable Whether links resume editing.
+ * @return string HTML.
+ */
+function extrachill_blog_dispatch_group_html( $title, $posts, $editable = false ) {
+	$html = '<section class="artist-dispatch-group"><h3>' . esc_html( $title ) . '</h3>';
+	if ( empty( $posts ) ) {
+		return $html . '<p class="artist-dispatch-empty">' . esc_html__( 'Nothing here yet.', 'extrachill-blog' ) . '</p></section>';
+	}
+	$html .= '<ul>';
+	foreach ( $posts as $post ) {
+		$title_text = $post->post_title ? $post->post_title : __( 'Untitled Artist Dispatch', 'extrachill-blog' );
+		$url        = $editable ? add_query_arg( 'post', $post->ID, home_url( '/submit/write/' ) ) : ( 'publish' === $post->post_status ? get_permalink( $post ) : '' );
+		$html      .= '<li><div><strong>' . esc_html( $title_text ) . '</strong><span>' . esc_html( get_the_modified_date( '', $post ) ) . '</span></div>';
+		if ( $url ) {
+			$html .= '<a href="' . esc_url( $url ) . '">' . esc_html( $editable ? __( 'Resume', 'extrachill-blog' ) : __( 'View', 'extrachill-blog' ) ) . '</a>';
+		}
+		$html .= '</li>';
+	}
+	return $html . '</ul></section>';
+}
+
+/**
+ * Render the approved dashboard.
+ *
+ * @param array $access Access state.
+ * @return string HTML.
+ */
+function extrachill_blog_dispatch_dashboard_html( $access ) {
+	$groups    = extrachill_blog_dispatch_dashboard_posts();
+	$artist_id = absint( isset( $access['artist_id'] ) ? $access['artist_id'] : 0 );
+	return '<section class="artist-dispatch-dashboard"><div class="artist-dispatch-dashboard__head"><div><p class="artist-dispatch-kicker">' . esc_html__( 'Approved contributor', 'extrachill-blog' ) . '</p><h2>' . esc_html__( 'Your Artist Dispatches', 'extrachill-blog' ) . '</h2></div><button id="artist-dispatch-new" class="button-1" type="button" data-artist="' . esc_attr( $artist_id ) . '">' . esc_html__( 'New Artist Dispatch', 'extrachill-blog' ) . '</button></div><p id="artist-dispatch-new-message" class="artist-dispatch-message" aria-live="polite"></p><div class="artist-dispatch-groups">' . extrachill_blog_dispatch_group_html( __( 'Drafts', 'extrachill-blog' ), $groups['draft'], true ) . extrachill_blog_dispatch_group_html( __( 'Awaiting Review', 'extrachill-blog' ), $groups['pending'] ) . extrachill_blog_dispatch_group_html( __( 'Published', 'extrachill-blog' ), $groups['publish'] ) . '</div></section>';
+}
+
+/**
+ * Render current-user cohort state.
+ *
+ * @return string HTML.
+ */
+function extrachill_blog_dispatch_state_html() {
+	if ( ! is_user_logged_in() ) {
+		return extrachill_blog_dispatch_logged_out_html();
+	}
+	$access = extrachill_blog_dispatch_access();
+	if ( is_wp_error( $access ) || empty( $access['eligibility']['policy']['pilot_enabled'] ) ) {
+		return '<section class="artist-dispatch-state is-closed"><h2>' . esc_html__( 'Artist Dispatch is not accepting requests', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'The pilot is currently unavailable. Your account and community access are unaffected.', 'extrachill-blog' ) . '</p></section>';
+	}
+
+	switch ( $access['status'] ) {
+		case 'approved':
+			if ( ! extrachill_blog_dispatch_is_approved( $access ) ) {
+				return '<section class="artist-dispatch-state is-closed"><h2>' . esc_html__( 'Writing access unavailable', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Your approval is recorded, but the required native writing role is unavailable. An editor has been asked to review it.', 'extrachill-blog' ) . '</p></section>';
+			}
+			if ( ! extrachill_blog_dispatch_has_current_terms( $access ) ) {
+				return '<section class="artist-dispatch-state is-closed"><h2>' . esc_html__( 'Current terms acceptance required', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'The audited Artist Dispatch request does not include the current guidelines and affiliation acknowledgement. Submit a current request before writing.', 'extrachill-blog' ) . '</p></section>';
+			}
+			if ( ! extrachill_blog_dispatch_has_editor_dependency() ) {
+				return '<section class="artist-dispatch-state is-closed"><h2>' . esc_html__( 'Writing editor unavailable', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Blocks Everywhere 3.6.0 or newer must be active before a new Artist Dispatch can be started.', 'extrachill-blog' ) . '</p></section>';
+			}
+			return extrachill_blog_dispatch_dashboard_html( $access );
+		case 'pending':
+			return '<section class="artist-dispatch-state"><h2>' . esc_html__( 'Your request is under review', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'An Extra Chill editor will review your represented artist and proposed story. Approval opens the writing dashboard; it does not guarantee publication.', 'extrachill-blog' ) . '</p></section>';
+		case 'rejected':
+			return '<section class="artist-dispatch-state"><h2>' . esc_html__( 'Your request was not approved', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Keep participating and refining the first-person story you want to tell. If reapplication is available, the unmet criteria below will update.', 'extrachill-blog' ) . '</p>' . extrachill_blog_dispatch_criteria_html( isset( $access['eligibility'] ) ? $access['eligibility'] : array() ) . '</section>';
+		case 'revoked':
+		case 'moderated':
+			return '<section class="artist-dispatch-state is-closed"><h2>' . esc_html__( 'Artist Dispatch access is unavailable', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'This account cannot use the submission pathway right now. Existing published work is unaffected.', 'extrachill-blog' ) . '</p></section>';
+		default:
+			$eligibility = isset( $access['eligibility'] ) ? $access['eligibility'] : array();
+			if ( ! empty( $eligibility['eligible'] ) ) {
+				return extrachill_blog_dispatch_request_html( $access );
+			}
+			return '<section class="artist-dispatch-state"><h2>' . esc_html__( 'Keep building trust in the community', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Artist Dispatch access is earned through a complete account, good moderation standing, meaningful participation, and a verified relationship to an artist project.', 'extrachill-blog' ) . '</p>' . extrachill_blog_dispatch_criteria_html( $eligibility ) . '</section>';
+	}
+}
+
+/**
+ * Render the complete guidelines default.
+ *
+ * @return string HTML.
+ */
+function extrachill_blog_dispatch_guidelines_html() {
+	return '<div class="artist-dispatch-guidelines"><header><p class="artist-dispatch-kicker">' . esc_html__( 'Artist Dispatch', 'extrachill-blog' ) . '</p><h1>' . esc_html__( 'Contributor Guidelines', 'extrachill-blog' ) . '</h1><p>' . esc_html__( 'These defaults are the trust contract between contributors, featured projects, editors, and readers.', 'extrachill-blog' ) . '</p></header>' .
+	'<section><h2>' . esc_html__( 'Write the story only you can tell', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Dispatches should offer meaningful creative context: a release story, songwriting or studio diary, tour journal, production breakdown, first-person scene report, or practical reflection from independent music work. Generic promotion, self-reviews, fake third-person journalism, and pasted or lightly rewritten press releases are not accepted.', 'extrachill-blog' ) . '</p></section>' .
+	'<section><h2>' . esc_html__( 'Accuracy, sources, and quotes', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Verify names, dates, credits, quotes, and factual claims. Link supporting sources where useful. Get permission for private quotes and distinguish firsthand memory from verified fact. Tell an editor promptly about an error; Extra Chill may correct, update, annotate, or remove material.', 'extrachill-blog' ) . '</p></section>' .
+	'<section><h2>' . esc_html__( 'Originality and prior publication', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Submit original work. Disclose any prior publication or substantial overlap before review. Plagiarism, fabricated experiences, invented quotes, and unattributed reuse are prohibited.', 'extrachill-blog' ) . '</p></section>' .
+	'<section><h2>' . esc_html__( 'Affiliations and conflicts', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Disclose your relationship to the featured artist or project and any relevant label, management, venue, promoter, sponsor, financial, family, or personal interest. Disclose free tickets, travel, products, payment, gifts, or special access. Every published Dispatch carries a visible first-party relationship disclosure.', 'extrachill-blog' ) . '</p></section>' .
+	'<section><h2>' . esc_html__( 'Images and media rights', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'The initial editor is text-first and does not accept uploads. For later editorial media requests, provide only work you own, commissioned, licensed, or have explicit permission to use, with creator credit and license details. Never submit unattributed images found online. Generated imagery requires disclosure.', 'extrachill-blog' ) . '</p></section>' .
+	'<section><h2>' . esc_html__( 'AI use', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'AI may assist with transcription, organization, research triage, or copyediting, but you remain accountable for every fact, quote, source, and claim. It may not fabricate reporting, attendance, listening experience, sources, or quotes. Do not enter sensitive or unpublished source material into unapproved systems. Disclose material AI assistance.', 'extrachill-blog' ) . '</p></section>' .
+	'<section><h2>' . esc_html__( 'Editorial control and submission limits', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Submission does not guarantee publication. Extra Chill may request revisions, edit for accuracy, clarity, length, style, and legal or safety concerns, delay or reject a piece, or remove published material. Active draft and review limits keep the pilot sustainable. Contact the editorial team promptly about corrections or withdrawal requests.', 'extrachill-blog' ) . '</p></section>' .
+	'<section><h2>' . esc_html__( 'Rights and compensation', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'You retain copyright. By submitting, you grant Extra Chill a non-exclusive license to edit, publish, archive, distribute, and promote accepted work. You confirm that you have the rights needed for the text and any supplied material. Submission or publication does not guarantee payment and is not paid placement. A separate written arrangement, if one exists, overrides these defaults.', 'extrachill-blog' ) . '</p></section></div>';
+}
+
+/**
+ * Render the secure canonical post editor host.
+ *
+ * @return string HTML.
+ */
+function extrachill_blog_dispatch_editor_html() {
+	$post = extrachill_blog_dispatch_editor_post();
+	if ( ! $post instanceof WP_Post ) {
+		return '';
+	}
+	return '<div class="artist-dispatch-write"><div class="artist-dispatch-write__intro"><a href="' . esc_url( home_url( '/submit/' ) ) . '">← ' . esc_html__( 'Your Dispatches', 'extrachill-blog' ) . '</a><p>' . esc_html__( 'Draft privately, preview through the real Extra Chill theme, then submit to the editorial queue.', 'extrachill-blog' ) . '</p></div><div class="artist-dispatch-editor"><textarea id="artist-dispatch-content" class="wp-editor-area">' . esc_textarea( $post->post_content ) . '</textarea></div></div>';
+}
+
+/**
+ * Replace native page shells with dynamic submission content.
+ *
+ * @param string $content Stored page content.
+ * @return string Rendered content.
+ */
+function extrachill_blog_dispatch_page_content( $content ) {
+	if ( ! is_main_query() || ! in_the_loop() ) {
+		return $content;
+	}
+	if ( extrachill_blog_dispatch_is_page( 'submit' ) ) {
+		return '<main class="artist-dispatch-page">' . extrachill_blog_dispatch_intro_html() . extrachill_blog_dispatch_state_html() . '</main>';
+	}
+	if ( extrachill_blog_dispatch_is_page( 'submit/guidelines' ) ) {
+		return extrachill_blog_dispatch_guidelines_html();
+	}
+	if ( extrachill_blog_dispatch_is_page( 'submit/write' ) ) {
+		return extrachill_blog_dispatch_editor_html();
+	}
+	return $content;
+}
+add_filter( 'the_content', 'extrachill_blog_dispatch_page_content' );
+
+/**
+ * Hide native page titles because each surface supplies its own heading.
+ *
+ * @param bool $show Whether to show the title.
+ * @return bool Filtered value.
+ */
+function extrachill_blog_dispatch_hide_page_title( $show ) {
+	return extrachill_blog_dispatch_is_page( 'submit' ) || extrachill_blog_dispatch_is_page( 'submit/guidelines' ) || extrachill_blog_dispatch_is_page( 'submit/write' ) ? false : $show;
+}
+add_filter( 'extrachill_show_page_title', 'extrachill_blog_dispatch_hide_page_title' );

--- a/inc/submit/presentation.php
+++ b/inc/submit/presentation.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Public Artist Dispatch presentation.
+ *
+ * @package ExtraChillBlog
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolve canonical represented artist display data.
+ *
+ * @param int $artist_id Artist profile ID on the Artist Platform site.
+ * @return array{name:string,url:string}|array Empty on failure.
+ */
+function extrachill_blog_dispatch_artist_display( $artist_id ) {
+	$artist_id = absint( $artist_id );
+	$blog_id   = function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'artist' ) ) : 0;
+	if ( ! $artist_id || ! $blog_id ) {
+		return array();
+	}
+
+	$switched = function_exists( 'switch_to_blog' ) && get_current_blog_id() !== $blog_id;
+	if ( $switched ) {
+		switch_to_blog( $blog_id );
+	}
+	try {
+		$post = get_post( $artist_id );
+		if ( ! $post || 'artist_profile' !== $post->post_type || 'publish' !== $post->post_status ) {
+			return array();
+		}
+		return array(
+			'name' => get_the_title( $post ),
+			'url'  => get_permalink( $post ),
+		);
+	} finally {
+		if ( $switched ) {
+			restore_current_blog();
+		}
+	}
+}
+
+/**
+ * Build the mandatory public label and first-party disclosure.
+ *
+ * @param int $post_id Published Dispatch ID.
+ * @return string Disclosure HTML, including a safe fallback when the profile or relationship disappeared.
+ */
+function extrachill_blog_dispatch_disclosure_html( $post_id ) {
+	if ( ! extrachill_blog_is_artist_dispatch( $post_id ) || 'publish' !== get_post_status( $post_id ) ) {
+		return '';
+	}
+
+	$artist_id = absint( get_post_meta( $post_id, EXTRACHILL_BLOG_DISPATCH_ARTIST_META, true ) );
+	$submitter = absint( get_post_meta( $post_id, EXTRACHILL_BLOG_DISPATCH_SUBMITTER_META, true ) );
+	$artist    = extrachill_blog_dispatch_artist_display( $artist_id );
+	if ( ! empty( $artist ) && function_exists( 'ec_get_artists_for_user' ) && ! in_array( $artist_id, array_map( 'absint', (array) ec_get_artists_for_user( $submitter, false ) ), true ) ) {
+		$artist = array();
+	}
+	$author = get_the_author_meta( 'display_name', (int) get_post_field( 'post_author', $post_id ) );
+	if ( empty( $artist ) ) {
+		$disclosure = sprintf(
+			/* translators: %s: contributor name. */
+			esc_html__( 'A first-person story by %s, who was verified as a member of or directly connected to the featured artist or project when this story was submitted. The original artist link is no longer available. Edited and published by Extra Chill.', 'extrachill-blog' ),
+			esc_html( $author )
+		);
+	} else {
+		$disclosure = sprintf(
+			/* translators: 1: contributor name, 2: linked artist name, 3: artist profile URL. */
+			wp_kses_post( __( 'A first-person story by %1$s, who is a member of or directly connected to <a href="%3$s">%2$s</a>. Edited and published by Extra Chill.', 'extrachill-blog' ) ),
+			esc_html( $author ),
+			esc_html( $artist['name'] ),
+			esc_url( $artist['url'] )
+		);
+	}
+	$notice = '<aside class="artist-dispatch-disclosure" aria-label="' . esc_attr__( 'Artist Dispatch disclosure', 'extrachill-blog' ) . '"><span class="artist-dispatch-label">' . esc_html__( 'Artist Dispatch', 'extrachill-blog' ) . '</span><p>' . $disclosure . '</p></aside>';
+
+	return $notice;
+}
+
+/**
+ * Prepend the visible label and first-party disclosure to published Dispatches.
+ *
+ * @param string $content Post content.
+ * @return string Filtered content.
+ */
+function extrachill_blog_dispatch_public_disclosure( $content ) {
+	if ( ! is_singular( 'post' ) || ! is_main_query() || ! in_the_loop() ) {
+		return $content;
+	}
+	$notice = extrachill_blog_dispatch_disclosure_html( get_the_ID() );
+	return $notice ? $notice . $content : $content;
+}
+add_filter( 'the_content', 'extrachill_blog_dispatch_public_disclosure', 8 );
+
+/**
+ * Add a public post class for marked Dispatches.
+ *
+ * @param string[] $classes Post classes.
+ * @return string[] Classes.
+ */
+function extrachill_blog_dispatch_post_class( $classes ) {
+	if ( extrachill_blog_is_artist_dispatch( get_the_ID() ) ) {
+		$classes[] = 'artist-dispatch-post';
+	}
+	return $classes;
+}
+add_filter( 'post_class', 'extrachill_blog_dispatch_post_class' );

--- a/tests/artist-dispatch-js.js
+++ b/tests/artist-dispatch-js.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const assert = require( 'node:assert/strict' );
+const fs = require( 'node:fs' );
+const vm = require( 'node:vm' );
+
+const dashboardSource = fs.readFileSync( require.resolve( '../assets/js/artist-dispatch.js' ), 'utf8' );
+const editorSource = fs.readFileSync( require.resolve( '../assets/js/artist-dispatch-editor.js' ), 'utf8' );
+
+let clickHandler;
+let requests = 0;
+let destination = '';
+let createRequest;
+const message = { textContent: '' };
+const button = {
+	dataset: { artist: '42' },
+	disabled: false,
+	addEventListener( event, callback ) {
+		if ( event === 'click' ) {
+			clickHandler = callback;
+		}
+	},
+};
+const apiFetch = options => {
+	requests++;
+	createRequest = options;
+	return Promise.resolve( { id: 91 } );
+};
+apiFetch.use = () => {};
+apiFetch.createNonceMiddleware = () => () => {};
+
+const context = {
+	window: {
+		wp: { apiFetch },
+		ecArtistDispatch: { nonce: 'nonce', termsVersion: 'v1', writeUrl: '/submit/write/' },
+		location: { assign: value => { destination = value; } },
+	},
+	document: {
+		getElementById( id ) {
+			if ( id === 'artist-dispatch-request' ) return null;
+			if ( id === 'artist-dispatch-new' ) return button;
+			if ( id === 'artist-dispatch-new-message' ) return message;
+			return null;
+		},
+	},
+	console,
+};
+vm.runInNewContext( dashboardSource, context );
+assert.equal( requests, 0, 'reload/mount must not create a post' );
+clickHandler();
+clickHandler();
+
+setImmediate( () => {
+	assert.equal( requests, 1, 'double click shares exactly one in-flight create' );
+	assert.equal( createRequest.headers[ 'X-Extra-Chill-Artist-Dispatch' ], 'create', 'create uses explicit validated server intent' );
+	assert.equal( Object.hasOwn( createRequest.data, 'meta' ), false, 'browser never authors provenance' );
+	assert.equal( destination, '/submit/write/?post=91', 'successful create navigates to the positive draft ID' );
+	assert.match( editorSource, /window\.wp\.editor\.PostTitle/, 'title is owned by core/editor' );
+	assert.match( editorSource, /savePost\(\)/, 'explicit saves use core/editor savePost' );
+	assert.match( editorSource, /status: 'pending'/, 'review submission uses native pending status' );
+	assert.doesNotMatch( editorSource, /setInterval|autosaves\//, 'host adds no custom autosave loop or route' );
+	console.log( 'All Artist Dispatch JavaScript tests passed.' );
+} );

--- a/tests/artist-dispatch.php
+++ b/tests/artist-dispatch.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Focused Artist Dispatch product and policy tests.
+ *
+ * Run: php tests/artist-dispatch.php
+ */
+
+define( 'ABSPATH', __DIR__ );
+define( 'OBJECT', 'OBJECT' );
+define( 'EXTRACHILL_BLOG_VERSION', 'test' );
+define( 'EXTRACHILL_BLOG_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
+define( 'EXTRACHILL_BLOG_PLUGIN_URL', 'https://example.com/plugin/' );
+eval( 'namespace Automattic\\Blocks_Everywhere; class Blocks_Everywhere { const VERSION = "3.6.0"; }' );
+
+class WP_Error {
+	private $code;
+	private $message;
+	private $data;
+	public function __construct( $code, $message, $data = array() ) {
+		$this->code = $code;
+		$this->message = $message;
+		$this->data = $data;
+	}
+	public function get_error_code() { return $this->code; }
+	public function get_error_message() { return $this->message; }
+	public function get_error_data() { return $this->data; }
+}
+class WP_Post {}
+class WP_Query {
+	public $found_posts = 0;
+	public $posts = array();
+	public function __construct() {
+		$this->found_posts = $GLOBALS['dispatch_query_count'];
+	}
+}
+
+$GLOBALS['dispatch_pages'] = array();
+$GLOBALS['dispatch_query_count'] = 0;
+$GLOBALS['dispatch_logged_in'] = true;
+$GLOBALS['dispatch_ability'] = null;
+$GLOBALS['dispatch_caps'] = array( 'edit_posts' => true, 'submit_for_review' => true );
+$GLOBALS['dispatch_options'] = array();
+
+function add_action() {}
+function add_filter() {}
+function apply_filters($hook, $value) { return $value; }
+function register_post_meta() {}
+function get_option($key, $default = false) { return array_key_exists($key, $GLOBALS['dispatch_options']) ? $GLOBALS['dispatch_options'][$key] : $default; }
+function update_option($key, $value) { $GLOBALS['dispatch_options'][$key] = $value; return true; }
+function add_option($key, $value) { if (array_key_exists($key, $GLOBALS['dispatch_options'])) return false; $GLOBALS['dispatch_options'][$key] = $value; return true; }
+function delete_option($key) { unset($GLOBALS['dispatch_options'][$key]); return true; }
+function sanitize_key($value) { return preg_replace('/[^a-z0-9_\-]/', '', strtolower($value)); }
+function wp_generate_uuid4() { static $uuid = 0; return '00000000-0000-4000-8000-' . str_pad((string) ++$uuid, 12, '0', STR_PAD_LEFT); }
+function maybe_serialize($value) { return serialize($value); }
+function __($text) { return $text; }
+function esc_html__($text) { return $text; }
+function esc_html($text) { return htmlspecialchars($text, ENT_QUOTES); }
+function esc_attr($text) { return htmlspecialchars((string) $text, ENT_QUOTES); }
+function esc_url($text) { return htmlspecialchars($text, ENT_QUOTES); }
+function wp_kses_post($text) { return $text; }
+function home_url($path = '') { return 'https://extrachill.com' . $path; }
+function wp_login_url($url) { return 'https://extrachill.com/login?to=' . rawurlencode($url); }
+function ec_get_site_url() { return 'https://community.extrachill.com'; }
+function ec_get_blog_id($key) { return 'artist' === $key ? 4 : 1; }
+function get_current_blog_id() { return 1; }
+function switch_to_blog() {}
+function restore_current_blog() {}
+function get_post($post_id) {
+	$post = new WP_Post();
+	$post->ID = $post_id;
+	$post->post_type = 'artist_profile';
+	$post->post_status = 'publish';
+	return $post;
+}
+function get_the_title($post) { return 'Test Artist'; }
+function get_permalink($post) { return 'https://artist.extrachill.com/test-artist/'; }
+function trailingslashit($url) { return rtrim($url, '/') . '/'; }
+function is_user_logged_in() { return $GLOBALS['dispatch_logged_in']; }
+function get_current_user_id() { return 7; }
+function current_user_can($cap) { return ! empty($GLOBALS['dispatch_caps'][$cap]); }
+function absint($value) { return abs((int) $value); }
+function sanitize_text_field($value) { return trim((string) $value); }
+function esc_url_raw($value) { return filter_var($value, FILTER_SANITIZE_URL); }
+function wp_parse_url($url, $component = -1) { return parse_url($url, $component); }
+function is_wp_error($value) { return $value instanceof WP_Error; }
+function get_page_by_path($path) {
+	$key = basename($path);
+	return isset($GLOBALS['dispatch_pages'][$key]) ? $GLOBALS['dispatch_pages'][$key] : null;
+}
+function wp_insert_post($data) {
+	$post = (object) array('ID' => count($GLOBALS['dispatch_pages']) + 1, 'post_content' => $data['post_content'], 'post_status' => $data['post_status'], 'post_parent' => $data['post_parent']);
+	$GLOBALS['dispatch_pages'][$data['post_name']] = $post;
+	return $post->ID;
+}
+function wp_get_ability() {
+	if ( null === $GLOBALS['dispatch_ability'] ) {
+		return null;
+	}
+	return new class {
+		public function execute() { return $GLOBALS['dispatch_ability']; }
+	};
+}
+
+require dirname( __DIR__ ) . '/inc/submit/artist-dispatch.php';
+
+$failures = 0;
+function check($label, $condition) {
+	global $failures;
+	if ($condition) {
+		echo "PASS: $label\n";
+		return;
+	}
+	echo "FAIL: $label\n";
+	++$failures;
+}
+
+extrachill_blog_provision_submit_pages();
+check('provisions all three native page shells', 3 === count($GLOBALS['dispatch_pages']));
+check('provisions feature pages as drafts', 'draft' === $GLOBALS['dispatch_pages']['submit']->post_status && 'draft' === $GLOBALS['dispatch_pages']['write']->post_status);
+$first_pages = $GLOBALS['dispatch_pages'];
+extrachill_blog_provision_submit_pages();
+check('provisioning is idempotent and preserves existing pages', $first_pages === $GLOBALS['dispatch_pages']);
+$GLOBALS['dispatch_pages']['submit']->post_content = 'Human content';
+check('human-edited page is no longer claimed or overwritten', 0 === extrachill_blog_provision_submit_page('submit', 'Artist Dispatch', EXTRACHILL_BLOG_DISPATCH_PAGES['submit']['sentinel']));
+$GLOBALS['dispatch_pages']['submit']->post_content = EXTRACHILL_BLOG_DISPATCH_PAGES['submit']['sentinel'];
+
+$GLOBALS['dispatch_logged_in'] = false;
+check('logged-out cohort has login and community actions', false !== strpos(extrachill_blog_dispatch_state_html(), 'Join the community'));
+$GLOBALS['dispatch_logged_in'] = true;
+$GLOBALS['dispatch_ability'] = null;
+check('missing Users ability fails closed', false !== strpos(extrachill_blog_dispatch_state_html(), 'not accepting requests'));
+
+$base = array('eligibility' => array('eligible' => false, 'criteria' => array(), 'reasons' => array(), 'policy' => array('pilot_enabled' => true)));
+foreach (array('pending' => 'under review', 'rejected' => 'not approved', 'revoked' => 'access is unavailable', 'moderated' => 'access is unavailable') as $status => $copy) {
+	$GLOBALS['dispatch_ability'] = array_merge($base, array('status' => $status));
+	check("$status cohort renders its bounded state", false !== strpos(extrachill_blog_dispatch_state_html(), $copy));
+}
+$GLOBALS['dispatch_ability'] = array_merge($base, array('status' => 'ineligible'));
+check('ineligible cohort renders progress path', false !== strpos(extrachill_blog_dispatch_state_html(), 'Keep building trust'));
+$eligible = $base;
+$eligible['status'] = 'none';
+$eligible['eligibility']['eligible'] = true;
+$eligible['eligibility']['criteria']['claimed_artist'] = array('passed' => true, 'artist_ids' => array(22));
+$GLOBALS['dispatch_ability'] = $eligible;
+check('eligible cohort consumes canonical artist IDs from owner contract', false !== strpos(extrachill_blog_dispatch_state_html(), 'value="22"'));
+$GLOBALS['dispatch_ability'] = array_merge($eligible, array('status' => 'approved', 'artist_id' => 22, 'terms_acknowledged' => true, 'terms_version' => EXTRACHILL_BLOG_DISPATCH_TERMS_VERSION));
+check('approved cohort renders native post dashboard', false !== strpos(extrachill_blog_dispatch_state_html(), 'New Artist Dispatch'));
+$GLOBALS['dispatch_ability']['eligibility']['policy']['pilot_enabled'] = false;
+check('disabled pilot fails closed for approved state', false !== strpos(extrachill_blog_dispatch_state_html(), 'not accepting requests'));
+
+$valid_blocks = array(
+	array('blockName' => 'core/paragraph', 'attrs' => array(), 'innerBlocks' => array()),
+	array('blockName' => 'core/embed', 'attrs' => array('url' => 'https://www.youtube.com/watch?v=1'), 'innerBlocks' => array()),
+);
+check('text and approved embed policy passes', true === extrachill_blog_dispatch_validate_blocks($valid_blocks));
+check('media block is rejected server-side', 'artist_dispatch_disallowed_block' === extrachill_blog_dispatch_validate_blocks(array(array('blockName' => 'core/image')))->get_error_code());
+check('unsupported embed host is rejected server-side', 'artist_dispatch_disallowed_embed' === extrachill_blog_dispatch_validate_blocks(array(array('blockName' => 'core/embed', 'attrs' => array('url' => 'https://example.org/video'))))->get_error_code());
+check('unstructured classic HTML is rejected server-side', 'artist_dispatch_unstructured_content' === extrachill_blog_dispatch_validate_blocks(array(array('blockName' => null, 'innerHTML' => '<p>raw</p>')))->get_error_code());
+check('normalizes string raw content', '<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->' === extrachill_blog_dispatch_raw_value('<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->'));
+check('normalizes canonical core raw envelope', 'wrapped' === extrachill_blog_dispatch_raw_value(array('raw' => 'wrapped')));
+check('provenance mutation is denied outside trusted writer', false === extrachill_blog_dispatch_guard_provenance_meta(null, 12, EXTRACHILL_BLOG_DISPATCH_SUBMITTER_META));
+$GLOBALS['extrachill_blog_dispatch_meta_write'] = 12;
+check('trusted scoped provenance writer is admitted', null === extrachill_blog_dispatch_guard_provenance_meta(null, 12, EXTRACHILL_BLOG_DISPATCH_SUBMITTER_META));
+unset($GLOBALS['extrachill_blog_dispatch_meta_write']);
+$lock = extrachill_blog_dispatch_acquire_lock('create', 7);
+check('first atomic operation lock succeeds', is_array($lock) && ! empty($lock['token']));
+check('parallel operation lock fails closed', is_wp_error(extrachill_blog_dispatch_acquire_lock('create', 7)));
+extrachill_blog_dispatch_release_lock($lock);
+
+if ($failures) {
+	exit(1);
+}
+echo "All Artist Dispatch PHP tests passed.\n";

--- a/tests/geographic-bridge-experiment.js
+++ b/tests/geographic-bridge-experiment.js
@@ -1,0 +1,98 @@
+const fs = require( 'node:fs' );
+const vm = require( 'node:vm' );
+
+const source = fs.readFileSync(
+	require.resolve( '../assets/js/geographic-bridge-experiment.js' ),
+	'utf8'
+);
+
+let listener;
+const document = {
+	addEventListener( name, callback ) {
+		if ( name === 'extrachill:experiment-assignment' ) {
+			listener = callback;
+		}
+	},
+	querySelectorAll() {
+		return [];
+	},
+};
+
+vm.runInNewContext( source, { document } );
+
+function check( label, condition ) {
+	if ( ! condition ) {
+		console.error( `FAIL: ${ label }` );
+		process.exit( 1 );
+	}
+	console.log( `PASS: ${ label }` );
+}
+
+function harness() {
+	const candidateAttributes = new Set( [ 'hidden', 'inert', 'aria-hidden' ] );
+	const sectionAttributes = new Set( [ 'hidden' ] );
+	const candidates = {
+		style: {},
+		removeAttribute( name ) {
+			candidateAttributes.delete( name );
+		},
+	};
+	const section = {
+		querySelectorAll( selector ) {
+			return selector === '.extrachill-blog-geographic-bridge-candidates'
+				? [ candidates ]
+				: [];
+		},
+		removeAttribute( name ) {
+			sectionAttributes.delete( name );
+		},
+	};
+
+	return { candidateAttributes, sectionAttributes, candidates, section };
+}
+
+const control = harness();
+check( 'missing provider event leaves candidates inert', control.candidateAttributes.has( 'inert' ) );
+listener( {
+	target: control.section,
+	detail: {
+		experiment_key: 'geo-bridge-holdout',
+		variant: 'control',
+		surface: 'single-post-bridge',
+	},
+} );
+check( 'deterministic control leaves candidates inert', control.candidateAttributes.has( 'inert' ) );
+check( 'deterministic control leaves geography-only section hidden', control.sectionAttributes.has( 'hidden' ) );
+
+const treatment = harness();
+listener( {
+	target: treatment.section,
+	detail: {
+		experiment_key: 'geo-bridge-holdout',
+		variant: 'treatment',
+		surface: 'single-post-bridge',
+	},
+} );
+check( 'deterministic treatment reveals candidates', ! treatment.candidateAttributes.has( 'hidden' ) );
+check( 'deterministic treatment makes candidates focusable', ! treatment.candidateAttributes.has( 'inert' ) );
+check( 'deterministic treatment restores accessibility', ! treatment.candidateAttributes.has( 'aria-hidden' ) );
+check( 'deterministic treatment preserves responsive card layout', treatment.candidates.style.display === 'contents' );
+check( 'deterministic treatment reveals geography-only section', ! treatment.sectionAttributes.has( 'hidden' ) );
+
+const invalid = harness();
+listener( {
+	target: invalid.section,
+	detail: {
+		experiment_key: 'geo-bridge-holdout',
+		variant: 'treatment',
+		surface: 'wrong-surface',
+	},
+} );
+check( 'invalid assignments fail closed', invalid.candidateAttributes.has( 'inert' ) );
+
+check( 'activation emits no independent analytics requests', ! source.includes( 'fetch(' ) && ! source.includes( 'sendBeacon' ) );
+check( 'activation consumes Network assignment event', source.includes( 'extrachill:experiment-assignment' ) );
+check( 'Network retains viewport exposure ownership', ! source.includes( 'IntersectionObserver' ) );
+check( 'preassigned treatment reconciles listener timing', source.includes( 'data-ec-experiment-variant="treatment"' ) );
+
+console.log( 'Geographic bridge experiment JS tests passed.' );

--- a/tests/integration/artist-dispatch-rest.php
+++ b/tests/integration/artist-dispatch-rest.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Artist Dispatch integration checks against real WordPress REST controllers.
+ *
+ * Run only in a disposable WordPress sandbox with this plugin active:
+ *   wp eval-file wp-content/plugins/extrachill-blog/tests/integration/artist-dispatch-rest.php
+ *
+ * The sandbox must not load Extra Chill Users or Artist Platform; this file
+ * registers exact test doubles for their public ability/relationship contracts.
+ */
+
+defined( 'ABSPATH' ) || exit( 1 );
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	class WP_CLI {
+		public static function log( $message ) { print $message . "\n"; }
+		public static function success( $message ) { print 'SUCCESS: ' . $message . "\n"; }
+		public static function error( $message ) { throw new RuntimeException( $message ); }
+	}
+}
+
+if ( ! function_exists( 'extrachill_blog_dispatch_access' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	$activated = activate_plugin( 'extrachill-blog/extrachill-blog.php' );
+	if ( is_wp_error( $activated ) ) {
+		WP_CLI::error( $activated->get_error_message() );
+	}
+}
+
+$ec_dispatch_failures      = 0;
+$ec_dispatch_access_states = array();
+$ec_dispatch_artists       = array();
+$ec_dispatch_created       = array();
+
+function ec_dispatch_integration_check( $label, $condition ) {
+	global $ec_dispatch_failures;
+	WP_CLI::log( ( $condition ? 'PASS: ' : 'FAIL: ' ) . $label );
+	if ( ! $condition ) {
+		++$ec_dispatch_failures;
+	}
+}
+
+if ( ! function_exists( 'ec_get_blog_id' ) ) {
+	function ec_get_blog_id( $key ) {
+		return 'artist' === $key || 'main' === $key ? get_current_blog_id() : 0;
+	}
+}
+if ( ! function_exists( 'ec_get_artists_for_user' ) ) {
+	function ec_get_artists_for_user( $user_id ) {
+		global $ec_dispatch_artists;
+		return isset( $ec_dispatch_artists[ $user_id ] ) ? $ec_dispatch_artists[ $user_id ] : array();
+	}
+}
+
+add_filter(
+	'extrachill_blog_artist_dispatch_access_state',
+	function() use ( &$ec_dispatch_access_states ) {
+		return isset( $ec_dispatch_access_states[ get_current_user_id() ] ) ? $ec_dispatch_access_states[ get_current_user_id() ] : array();
+	}
+);
+
+register_post_type( 'artist_profile', array( 'public' => true, 'show_in_rest' => true ) );
+add_role(
+	EXTRACHILL_BLOG_DISPATCH_ROLE,
+	'Artist Dispatch Contributor',
+	array(
+		'read'              => true,
+		'edit_posts'        => true,
+		'delete_posts'      => true,
+		'submit_for_review' => true,
+	)
+);
+
+$editor_id = wp_create_user( 'dispatch_editor_' . wp_generate_password( 6, false ), wp_generate_password(), 'dispatch-editor@example.test' );
+$one_id    = wp_create_user( 'dispatch_one_' . wp_generate_password( 6, false ), wp_generate_password(), 'dispatch-one@example.test' );
+$two_id    = wp_create_user( 'dispatch_two_' . wp_generate_password( 6, false ), wp_generate_password(), 'dispatch-two@example.test' );
+$author_id = wp_create_user( 'dispatch_author_' . wp_generate_password( 6, false ), wp_generate_password(), 'dispatch-author@example.test' );
+$ec_dispatch_created = array( $editor_id, $one_id, $two_id, $author_id );
+( new WP_User( $editor_id ) )->set_role( 'editor' );
+( new WP_User( $one_id ) )->set_role( EXTRACHILL_BLOG_DISPATCH_ROLE );
+( new WP_User( $two_id ) )->set_role( EXTRACHILL_BLOG_DISPATCH_ROLE );
+( new WP_User( $author_id ) )->set_role( 'author' );
+( new WP_User( $author_id ) )->add_role( EXTRACHILL_BLOG_DISPATCH_ROLE );
+
+wp_set_current_user( $editor_id );
+$artist_id = wp_insert_post(
+	array(
+		'post_type'   => 'artist_profile',
+		'post_status' => 'publish',
+		'post_title'  => 'Integration Artist',
+	),
+	true
+);
+$ec_dispatch_artists[ $one_id ] = array( $artist_id );
+$ec_dispatch_artists[ $two_id ] = array( $artist_id );
+$approved = function( $artist ) {
+	return array(
+		'status'             => 'approved',
+		'artist_id'          => $artist,
+		'terms_acknowledged' => true,
+		'terms_version'      => EXTRACHILL_BLOG_DISPATCH_TERMS_VERSION,
+		'eligibility'        => array(
+			'eligible' => true,
+			'policy'   => array( 'pilot_enabled' => true ),
+			'criteria' => array( 'claimed_artist' => array( 'passed' => true, 'artist_ids' => array( $artist ) ) ),
+			'reasons'  => array(),
+		),
+	);
+};
+$ec_dispatch_access_states[ $one_id ] = $approved( $artist_id );
+$ec_dispatch_access_states[ $two_id ] = $approved( $artist_id );
+
+$valid_content = '<!-- wp:paragraph --><p>Integration content.</p><!-- /wp:paragraph -->';
+$create = function( $user_id ) use ( $valid_content ) {
+	wp_set_current_user( $user_id );
+	$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
+	$request->set_header( EXTRACHILL_BLOG_DISPATCH_CREATE_HEADER, 'create' );
+	$request->set_body_params( array( 'title' => '', 'content' => '', 'status' => 'draft' ) );
+	return rest_do_request( $request );
+};
+
+wp_set_current_user( $one_id );
+$unmarked_create = new WP_REST_Request( 'POST', '/wp/v2/posts' );
+$unmarked_create->set_body_params( array( 'title' => 'Bypass', 'content' => $valid_content, 'status' => 'draft' ) );
+ec_dispatch_integration_check( 'grant-only user cannot create an unmarked post', 403 === rest_do_request( $unmarked_create )->get_status() );
+
+$created_response = $create( $one_id );
+$created_data     = $created_response->get_data();
+if ( 201 !== $created_response->get_status() ) {
+	WP_CLI::log( 'CREATE DIAGNOSTIC: ' . wp_json_encode( $created_data ) );
+}
+$dispatch_id      = isset( $created_data['id'] ) ? (int) $created_data['id'] : 0;
+ec_dispatch_integration_check( 'validated core REST creation succeeds once', 201 === $created_response->get_status() && $dispatch_id > 0 );
+ec_dispatch_integration_check( 'server stamps source and real submitter', EXTRACHILL_BLOG_DISPATCH_SOURCE === get_post_meta( $dispatch_id, EXTRACHILL_BLOG_DISPATCH_SOURCE_META, true ) && $one_id === (int) get_post_meta( $dispatch_id, EXTRACHILL_BLOG_DISPATCH_SUBMITTER_META, true ) );
+ec_dispatch_integration_check( 'server copies audited terms rather than client data', EXTRACHILL_BLOG_DISPATCH_TERMS_VERSION === get_post_meta( $dispatch_id, EXTRACHILL_BLOG_DISPATCH_TERMS_META, true ) );
+
+wp_set_current_user( $editor_id );
+$unmarked_id = wp_insert_post( array( 'post_type' => 'post', 'post_status' => 'draft', 'post_author' => $one_id, 'post_title' => 'Legacy unmarked' ), true );
+wp_set_current_user( $one_id );
+$convert = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $unmarked_id );
+$convert->set_body_params( array( 'id' => $unmarked_id, 'meta' => array( EXTRACHILL_BLOG_DISPATCH_SOURCE_META => EXTRACHILL_BLOG_DISPATCH_SOURCE ) ) );
+ec_dispatch_integration_check( 'unmarked post cannot be converted with provenance', 400 === rest_do_request( $convert )->get_status() );
+
+$autosave = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $dispatch_id . '/autosaves' );
+$autosave->set_body_params(
+	array(
+		'id'      => $dispatch_id,
+		'title'   => array( 'raw' => 'Autosaved Dispatch' ),
+		'content' => array( 'raw' => $valid_content ),
+		'excerpt' => array( 'raw' => '' ),
+		'meta'    => array(),
+	)
+);
+$autosave_response = rest_do_request( $autosave );
+ec_dispatch_integration_check( 'real core autosaves controller accepts canonical raw envelopes', 201 === $autosave_response->get_status() || 200 === $autosave_response->get_status() );
+foreach ( array( 'author' => $two_id, 'status' => 'pending', 'slug' => 'forged', 'featured_media' => 1 ) as $field => $value ) {
+	$forbidden_autosave = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $dispatch_id . '/autosaves' );
+	$forbidden_autosave->set_body_params( array( 'id' => $dispatch_id, 'content' => array( 'raw' => $valid_content ), $field => $value ) );
+	$forbidden_response = rest_do_request( $forbidden_autosave );
+	if ( 400 !== $forbidden_response->get_status() ) {
+		WP_CLI::log( "AUTOSAVE {$field} DIAGNOSTIC: " . $forbidden_response->get_status() . ' ' . wp_json_encode( $forbidden_response->get_data() ) );
+	}
+	ec_dispatch_integration_check( "autosave rejects protected {$field} field", 400 === $forbidden_response->get_status() );
+}
+add_filter( 'extrachill_blog_artist_dispatch_is_autosave_request', '__return_false' );
+
+wp_set_current_user( $two_id );
+$foreign_request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $dispatch_id );
+$foreign_request->set_query_params( array( 'context' => 'edit' ) );
+$foreign_get = rest_do_request( $foreign_request );
+ec_dispatch_integration_check( 'second contributor cannot read first contributor draft', in_array( $foreign_get->get_status(), array( 401, 403, 404 ), true ) );
+
+$ec_dispatch_access_states[ $one_id ]['status'] = 'revoked';
+wp_set_current_user( $one_id );
+$revoked_update = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $dispatch_id );
+$revoked_update->set_body_params( array( 'id' => $dispatch_id, 'title' => 'Revoked edit' ) );
+ec_dispatch_integration_check( 'revocation blocks normal updates', 403 === rest_do_request( $revoked_update )->get_status() );
+ec_dispatch_integration_check( 'revocation blocks autosaves', in_array( rest_do_request( $autosave )->get_status(), array( 401, 403 ), true ) );
+$ec_dispatch_access_states[ $one_id ] = $approved( $artist_id );
+$ec_dispatch_access_states[ $one_id ]['eligibility']['policy']['pilot_enabled'] = false;
+ec_dispatch_integration_check( 'disabled pilot blocks contributor writes', 403 === rest_do_request( $revoked_update )->get_status() );
+$ec_dispatch_access_states[ $one_id ] = $approved( $artist_id );
+foreach ( array( 'publish', 'future' ) as $forbidden_status ) {
+	$contributor_publication = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $dispatch_id );
+	$contributor_publication->set_body_params( array( 'id' => $dispatch_id, 'status' => $forbidden_status ) );
+	ec_dispatch_integration_check( "contributor cannot set {$forbidden_status} status", 403 === rest_do_request( $contributor_publication )->get_status() );
+}
+
+wp_set_current_user( $editor_id );
+wp_update_post( array( 'ID' => $dispatch_id, 'post_content' => '<!-- wp:image {"id":1} /-->' ) );
+wp_set_current_user( $one_id );
+$status_only = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $dispatch_id );
+$status_only->set_body_params( array( 'id' => $dispatch_id, 'status' => 'pending' ) );
+ec_dispatch_integration_check( 'status-only pending transition validates stored effective content', 400 === rest_do_request( $status_only )->get_status() );
+wp_set_current_user( $editor_id );
+wp_update_post( array( 'ID' => $dispatch_id, 'post_content' => $valid_content ) );
+wp_set_current_user( $one_id );
+ec_dispatch_integration_check( 'valid draft transitions to pending through core REST', 200 === rest_do_request( $status_only )->get_status() );
+$pending_edit = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $dispatch_id );
+$pending_edit->set_body_params( array( 'id' => $dispatch_id, 'title' => 'Too late' ) );
+ec_dispatch_integration_check( 'pending Dispatch is locked to contributor edits', 403 === rest_do_request( $pending_edit )->get_status() );
+
+wp_set_current_user( $editor_id );
+$schedule_request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $dispatch_id );
+$schedule_request->set_body_params( array( 'id' => $dispatch_id, 'status' => 'future', 'date_gmt' => gmdate( 'c', time() + HOUR_IN_SECONDS ) ) );
+$scheduled = rest_do_request( $schedule_request );
+ec_dispatch_integration_check( 'editor owns scheduled publication after pending review', 200 === $scheduled->get_status() && 'future' === get_post_status( $dispatch_id ) );
+$return_pending = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $dispatch_id );
+$return_pending->set_body_params( array( 'id' => $dispatch_id, 'status' => 'pending', 'date_gmt' => gmdate( 'c' ) ) );
+rest_do_request( $return_pending );
+$ec_dispatch_artists[ $one_id ] = array();
+$publish_request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $dispatch_id );
+$publish_request->set_body_params( array( 'id' => $dispatch_id, 'status' => 'publish' ) );
+$published = rest_do_request( $publish_request );
+ec_dispatch_integration_check( 'editor owns final publication after pending even if relationship later disappears', 200 === $published->get_status() && 'publish' === get_post_status( $dispatch_id ) );
+wp_set_current_user( 0 );
+$public = rest_do_request( new WP_REST_Request( 'GET', '/wp/v2/posts/' . $dispatch_id ) );
+$public_meta = isset( $public->get_data()['meta'] ) ? $public->get_data()['meta'] : array();
+ec_dispatch_integration_check( 'anonymous public REST response omits all provenance', 200 === $public->get_status() && ! array_intersect( extrachill_blog_dispatch_provenance_keys(), array_keys( $public_meta ) ) );
+
+wp_set_current_user( $editor_id );
+$fallback = extrachill_blog_dispatch_disclosure_html( $dispatch_id );
+ec_dispatch_integration_check( 'published disclosure survives removed relationship with safe fallback', false !== strpos( $fallback, 'Artist Dispatch' ) && false !== strpos( $fallback, 'artist link is no longer available' ) );
+
+foreach ( array_keys( (array) get_option( EXTRACHILL_BLOG_DISPATCH_PAGES_OPTION, array() ) ) as $path ) {
+	$page = get_page_by_path( $path, OBJECT, 'page' );
+	if ( $page ) {
+		wp_delete_post( $page->ID, true );
+	}
+}
+delete_option( EXTRACHILL_BLOG_DISPATCH_PAGES_OPTION );
+$human_page = wp_insert_post( array( 'post_type' => 'page', 'post_status' => 'draft', 'post_name' => 'submit', 'post_title' => 'Human Submit', 'post_content' => 'Human content' ), true );
+ec_dispatch_integration_check( 'existing human page is never claimed or overwritten', false === extrachill_blog_provision_submit_pages() && 'Human content' === get_post_field( 'post_content', $human_page ) );
+wp_delete_post( $human_page, true );
+$fail_guidelines = function( $empty, $postarr ) {
+	return isset( $postarr['post_name'] ) && 'guidelines' === $postarr['post_name'] ? true : $empty;
+};
+add_filter( 'wp_insert_post_empty_content', $fail_guidelines, 100, 2 );
+ec_dispatch_integration_check( 'partial hierarchy failure stops provisioning', false === extrachill_blog_provision_submit_pages() );
+remove_filter( 'wp_insert_post_empty_content', $fail_guidelines, 100 );
+ec_dispatch_integration_check( 'failed hierarchy can retry to exact completion', true === extrachill_blog_provision_submit_pages() );
+
+$first_lock = extrachill_blog_dispatch_acquire_lock( 'race', $one_id );
+$expired_lock = $first_lock;
+$expired_lock['expires'] = time() - 1;
+update_option( $first_lock['key'], $expired_lock, false );
+$successor_lock = extrachill_blog_dispatch_acquire_lock( 'race', $one_id );
+extrachill_blog_dispatch_release_lock( $first_lock );
+ec_dispatch_integration_check( 'expired lock takeover receives a distinct owner token', is_array( $successor_lock ) && $successor_lock['token'] !== $first_lock['token'] );
+ec_dispatch_integration_check( 'stale owner release cannot delete successor lock', is_wp_error( extrachill_blog_dispatch_acquire_lock( 'race', $one_id ) ) );
+extrachill_blog_dispatch_release_lock( $successor_lock );
+
+wp_set_current_user( $editor_id );
+foreach ( array( $dispatch_id, $unmarked_id ) as $post_id ) {
+	wp_delete_post( $post_id, true );
+}
+foreach ( $ec_dispatch_created as $user_id ) {
+	require_once ABSPATH . 'wp-admin/includes/user.php';
+	wp_delete_user( $user_id );
+}
+
+if ( $ec_dispatch_failures ) {
+	WP_CLI::error( $ec_dispatch_failures . ' Artist Dispatch integration check(s) failed.' );
+}
+WP_CLI::success( 'All Artist Dispatch core REST integration checks passed.' );

--- a/tests/network-bridge.php
+++ b/tests/network-bridge.php
@@ -8,17 +8,39 @@
  */
 
 define( 'ABSPATH', __DIR__ . '/' );
+define( 'EXTRACHILL_BLOG_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
+define( 'EXTRACHILL_BLOG_PLUGIN_URL', 'https://extrachill.test/wp-content/plugins/extrachill-blog/' );
 
 // Test doubles intentionally mirror WordPress and shared renderer signatures.
 // phpcs:disable Squiz.Commenting.FunctionComment.Missing,Squiz.Commenting.FunctionComment.MissingParamTag,WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid,Universal.NamingConventions.NoReservedKeywordParameterNames.classFound
 
-$test_cards_by_taxonomy = array();
-$test_resolver_calls    = array();
-$test_is_post           = true;
-$test_enqueued_styles   = array();
+$test_cards_by_taxonomy    = array();
+$test_resolver_calls       = array();
+$test_is_post              = true;
+$test_enqueued_styles      = array();
+$test_enqueued_scripts     = array();
+$test_registered_scripts   = array(
+	'extrachill-experiment-assignment'  => array( 'registered' => true ),
+	'extrachill-blog-geographic-bridge' => array(),
+);
+$test_experiment_available = true;
+$test_post_type            = 'post';
+$test_post_status          = 'publish';
 
 /** Stub action registration. */
 function add_action() {}
+
+/** Stub filter registration. */
+function add_filter() {}
+
+/** Stub script registration. */
+function wp_register_script( $handle, $src, $dependencies ) {
+	global $test_registered_scripts;
+	$test_registered_scripts[ $handle ] = array(
+		'src'          => $src,
+		'dependencies' => $dependencies,
+	);
+}
 
 /** Stub current post ID. */
 function get_the_ID() {
@@ -51,10 +73,54 @@ function esc_url( $url ) {
 	return htmlspecialchars( $url, ENT_QUOTES, 'UTF-8' );
 }
 
+/** Stub WordPress JSON encoding. */
+function wp_json_encode( $value ) {
+	return json_encode( $value ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Standalone WordPress test double.
+}
+
 /** Capture enqueued styles. */
 function wp_enqueue_style( $handle ) {
 	global $test_enqueued_styles;
 	$test_enqueued_styles[] = $handle;
+}
+
+/** Capture enqueued scripts. */
+function wp_enqueue_script( $handle ) {
+	global $test_enqueued_scripts;
+	$test_enqueued_scripts[] = $handle;
+}
+
+/** Report registered dependency state. */
+function wp_script_is( $handle, $status ) {
+	global $test_registered_scripts;
+	return 'registered' === $status && ! empty( $test_registered_scripts[ $handle ] );
+}
+
+/** Return controlled post type. */
+function get_post_type() {
+	global $test_post_type;
+	return $test_post_type;
+}
+
+/** Return controlled post status. */
+function get_post_status() {
+	global $test_post_status;
+	return $test_post_status;
+}
+
+/** Mirror Network's cache-neutral attribute contract. */
+function extrachill_experiment_attributes( $key, $surface, $context ) {
+	global $test_experiment_available;
+	if ( ! $test_experiment_available ) {
+		return '';
+	}
+
+	return sprintf(
+		'data-ec-experiment-key="%s" data-ec-experiment-surface="%s" data-ec-experiment-variant="control" data-ec-experiment-context="%s"',
+		esc_attr( $key ),
+		esc_attr( $surface ),
+		esc_attr( wp_json_encode( $context ) )
+	);
 }
 
 /** Stub the shared verified resolver and capture its contract. */
@@ -89,6 +155,7 @@ function extrachill_cross_site_link_button( $card, $class = '' ) {
 }
 
 require_once dirname( __DIR__ ) . '/inc/single/network-bridge.php';
+extrachill_blog_register_geographic_bridge_script();
 
 /** Assert strict equality. */
 function assert_same( $expected, $actual, $message ) {
@@ -143,6 +210,7 @@ $festival_wire  = bridge_card( 'wire', 'High Water', 'festival' );
 $cards          = resolve_cards( array( $artist_profile, $festival_wire ), array( $city_event, $community ) );
 assert_same( array( 'artist', 'events', 'wire', 'community' ), array_column( $cards, 'site_key' ), 'Mixed terms should preserve slot order while geography only fills capacity.' );
 assert_same( 'High Water', $cards[2]['term_name'], 'A location card must not displace a primary festival destination.' );
+assert_same( count( $cards ), count( array_unique( array_column( $cards, 'site_key' ) ) ), 'Treatment cards must not duplicate a destination slot.' );
 
 $cards = resolve_cards( array(), array() );
 assert_same( array(), $cards, 'Posts without a verified destination must fail closed.' );
@@ -159,5 +227,51 @@ assert_same( true, false !== strpos( $mobile_output, 'network-bridge-links ec-cr
 assert_same( true, false !== strpos( $mobile_output, 'button-3 button-small ec-cross-site-link network-bridge-link' ), 'Mobile cards should use the shared compact card renderer.' );
 assert_same( true, in_array( 'extrachill-network-bridge', $test_enqueued_styles, true ), 'A rendered bridge should enqueue the shared responsive stylesheet.' );
 assert_same( true, false !== strpos( $mobile_output, 'utm_medium=network_bridge' ), 'Rendered destinations should retain shared UTM instrumentation.' );
+assert_same( true, false !== strpos( $mobile_output, 'data-ec-experiment-key="geo-bridge-holdout"' ), 'Eligible bridges should use Network experiment markup.' );
+assert_same( true, false !== strpos( $mobile_output, 'data-ec-experiment-variant="control"' ), 'Cached markup must contain only declared control state.' );
+assert_same( true, false === strpos( $mobile_output, 'visitor-' ), 'Cached markup must not contain visitor identity.' );
+assert_same( true, false !== strpos( $mobile_output, 'hidden inert aria-hidden="true"' ), 'Geographic candidates must be inert and unfocusable before activation.' );
+assert_same( true, false !== strpos( $mobile_output, 'class="network-bridge-section related-tax-section"' ) && false !== strpos( $mobile_output, ' hidden>' ), 'A geography-only bridge must remain hidden in control.' );
+assert_same( true, in_array( 'extrachill-blog-geographic-bridge', $test_enqueued_scripts, true ), 'Eligible bridges should enqueue treatment activation.' );
+assert_same( array( 'extrachill-experiment-assignment' ), $test_registered_scripts['extrachill-blog-geographic-bridge']['dependencies'], 'Viewport exposure must remain wired through Network assignment.' );
+
+$definition = extrachill_blog_register_bridge_experiment( array() );
+assert_same( array( 'geo-bridge-holdout' ), array_keys( $definition ), 'Blog should register exactly one code-owned experiment.' );
+assert_same(
+	array(
+		'control'   => 50,
+		'treatment' => 50,
+	),
+	$definition['geo-bridge-holdout']['variants'],
+	'The holdout must use exact 50/50 weights.'
+);
+assert_same( array( 'single-post-bridge' ), $definition['geo-bridge-holdout']['surfaces'], 'The experiment must be bounded to the single-post bridge.' );
+
+resolve_cards( array(), array( $city_event ) );
+assert_same( true, extrachill_blog_geographic_bridge_experiment_eligible( array( 'post_id' => '64' ), 'single-post-bridge' ), 'Published posts with verified geographic capacity should be eligible.' );
+resolve_cards( array( $artist_event, $primary_community ), array( $city_event, $community ) );
+assert_same( false, extrachill_blog_geographic_bridge_experiment_eligible( array( 'post_id' => '64' ), 'single-post-bridge' ), 'Posts without vacant geographic capacity must be ineligible.' );
+assert_same( false, extrachill_blog_geographic_bridge_experiment_eligible( array( 'post_id' => '64' ), 'other-surface' ), 'Other surfaces must be ineligible.' );
+$test_post_status = 'draft';
+assert_same( false, extrachill_blog_geographic_bridge_experiment_eligible( array( 'post_id' => '64' ), 'single-post-bridge' ), 'Non-published posts must be ineligible.' );
+$test_post_status = 'publish';
+
+resolve_cards( array( $artist_profile ), array( $city_event ) );
+$test_registered_scripts['extrachill-experiment-assignment'] = array();
+ob_start();
+extrachill_blog_network_bridge();
+$dependency_output = ob_get_clean();
+assert_same( true, false !== strpos( $dependency_output, 'Kid Lake' ), 'Primary artist cards must survive experiment dependency absence.' );
+assert_same( true, false === strpos( $dependency_output, 'Charleston' ), 'Geographic cards must fail closed when Network assignment is absent.' );
+assert_same( true, false === strpos( $dependency_output, 'data-ec-experiment-key' ), 'Dependency absence must emit no partial experiment markup.' );
+$test_registered_scripts['extrachill-experiment-assignment'] = array( 'registered' => true );
+
+resolve_cards( array(), array( $city_event ) );
+$test_experiment_available = false;
+ob_start();
+extrachill_blog_network_bridge();
+$provider_output = ob_get_clean();
+assert_same( '', $provider_output, 'Missing or invalid experiment configuration must leave geography-only control empty.' );
+$test_experiment_available = true;
 
 fwrite( STDOUT, "Network bridge tests passed.\n" ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- CLI test output.

--- a/tests/run-artist-dispatch-integration.sh
+++ b/tests/run-artist-dispatch-integration.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+artifact_root="${TMPDIR:-/tmp}/extrachill-blog-artist-dispatch-integration"
+
+wp-codebox run \
+  --mount "${repo_root}:/wordpress/wp-content/plugins/extrachill-blog" \
+  --command wordpress.run-php \
+  --arg "code-file=${repo_root}/tests/integration/artist-dispatch-rest.php" \
+  --wp nightly \
+  --artifacts "${artifact_root}" \
+  --json


### PR DESCRIPTION
## Summary
- register the code-owned `geo-bridge-holdout` experiment on `single-post-bridge` with exact 50/50 `control` and `treatment` weights
- keep artist/festival primary cards server-rendered and unchanged while treatment reveals only verified location/venue cards for otherwise-vacant Events or Community slots
- consume Network's cache-safe assignment and signed 50%-viewport exposure lifecycle without adding identity, analytics, assignment, or generic experiment infrastructure

## Population and assignment
Eligible population is limited to published single posts where Network's verified location/venue resolution produces at least one Events or Community card after artist/festival cards claim their primary destination slots. The consumer callback re-resolves the post and cards from the bounded `post_id` context on assignment and exposure validation.

Network owns deterministic assignment from its existing authenticated/anonymous subject providers. Control and treatment each have weight 50. Analytics' existing identity and GPC/DNT provider contract remains the only measurement provider; Blog does not mint or inspect identity.

## Control and treatment
Control renders only the existing non-geographic artist/festival bridge. Treatment preserves those cards and reveals verified geographic candidates in canonical slot order without replacing or duplicating primary destinations.

Geographic candidates are present only as hidden, `inert`, `aria-hidden` markup until a measured treatment assignment activates them. The activation listener also reconciles an already-applied treatment attribute to avoid a deferred-script timing race, and uses `display: contents` after activation to preserve the responsive card layout.

## Cache and privacy model
Anonymous full-page HTML contains only Network's code-owned experiment key, surface, declared control state, bounded post context, and inert candidate markup. It contains no visitor subject or server-resolved assignment. Cached desktop/mobile responses therefore remain shareable and control-safe.

Missing Network helpers/scripts, invalid experiment configuration, missing identity/privacy providers, GPC/DNT, invalid assignment responses, or JavaScript failure all leave control unchanged and unmeasured. If experiment dependencies are unavailable, primary artist/festival cards continue rendering while geographic candidates fail closed.

## Exposure and analytics
The Blog script depends on Network's assignment asset and listens only for `extrachill:experiment-assignment`. Network retains signed assignment validation and 50%-viewport exposure ownership. Blog emits no independent analytics event, fetch, beacon, or card-specific attribution. Existing canonical bridge destinations, UTM parameters, click instrumentation, and Network card viewport instrumentation remain intact; Analytics #210 can report broad post-assignment engagement without claiming geographic-card causality.

## Verification
Passed:
- `php tests/network-bridge.php`
- `node tests/geographic-bridge-experiment.js`
- changed-file PHP syntax checks
- changed-file JavaScript syntax checks
- `vendor/bin/phpcs --standard=WordPress inc/single/network-bridge.php tests/network-bridge.php`
- `composer validate --no-check-publish`
- `git diff --check`

No production build is configured or required for the plain deferred JavaScript asset.

`composer test` passes every standalone PHP/JavaScript test, then reaches the repository-wide PHPCS step and fails on pre-existing violations in untouched `inc/single/login-register-cta.php`, `inc/core/co-authors.php`, `inc/core/ads-filter.php`, and `inc/core/admin-customizations.php`, matching the baseline documented by #68.

Closes #66