### PR TITLE
refactor: adopt versioned geographic holdout lifecycle

### DIFF
--- a/inc/single/network-bridge.php
+++ b/inc/single/network-bridge.php
@@ -72,6 +72,10 @@ function extrachill_blog_register_bridge_experiment( $definitions ) {
 	}
 
 	$definitions['geo-bridge-holdout'] = array(
+		'key'                  => 'geo-bridge-holdout',
+		'definition_version'   => 1,
+		'assignment_policy'    => 'weighted_random',
+		'default_state'        => 'inactive',
 		'default_variant'      => 'control',
 		'control_variant'      => 'control',
 		'variants'             => array(
@@ -220,8 +224,11 @@ function extrachill_blog_network_bridge() {
 		return;
 	}
 
+	$experiment_active     = ! empty( $groups['geographic'] )
+		&& function_exists( 'extrachill_experiment_is_active' )
+		&& extrachill_experiment_is_active( 'geo-bridge-holdout' );
 	$experiment_attributes = '';
-	if ( ! empty( $groups['geographic'] )
+	if ( $experiment_active
 		&& function_exists( 'extrachill_experiment_attributes' )
 		&& function_exists( 'wp_script_is' )
 		&& wp_script_is( 'extrachill-experiment-assignment', 'registered' )
@@ -233,13 +240,13 @@ function extrachill_blog_network_bridge() {
 		);
 	}
 
-	if ( empty( $groups['primary'] ) && '' === $experiment_attributes ) {
+	if ( $experiment_active && empty( $groups['primary'] ) && '' === $experiment_attributes ) {
 		return;
 	}
 
-	if ( '' !== $experiment_attributes ) {
+	if ( $experiment_active && '' !== $experiment_attributes ) {
 		wp_enqueue_script( 'extrachill-blog-geographic-bridge' );
-	} else {
+	} elseif ( $experiment_active ) {
 		$groups['geographic'] = array();
 	}
 
@@ -252,14 +259,16 @@ function extrachill_blog_network_bridge() {
 	}
 	foreach ( $groups['geographic'] as $card ) {
 		if ( ! empty( $card['site_key'] ) && ! isset( $cards_by_site[ $card['site_key'] ] ) ) {
-			$cards_by_site[ $card['site_key'] ]    = $card;
-			$geographic_sites[ $card['site_key'] ] = true;
+			$cards_by_site[ $card['site_key'] ] = $card;
+			if ( $experiment_active ) {
+				$geographic_sites[ $card['site_key'] ] = true;
+			}
 		}
 	}
 
 	wp_enqueue_style( 'extrachill-network-bridge' );
 	?>
-	<div class="network-bridge-section related-tax-section" aria-labelledby="<?php echo esc_attr( $args['heading_id'] ); ?>" <?php echo $experiment_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Network returns fully escaped, cache-neutral attributes. ?><?php echo empty( $groups['primary'] ) ? ' hidden' : ''; ?>>
+	<div class="network-bridge-section related-tax-section" aria-labelledby="<?php echo esc_attr( $args['heading_id'] ); ?>" <?php echo $experiment_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Network returns fully escaped, cache-neutral attributes. ?><?php echo $experiment_active && empty( $groups['primary'] ) ? ' hidden' : ''; ?>>
 		<h3 class="network-bridge-header related-tax-header" id="<?php echo esc_attr( $args['heading_id'] ); ?>"><?php echo esc_html( $args['heading_text'] ); ?></h3>
 		<div class="network-bridge-links ec-cross-site-links">
 			<?php foreach ( $args['slot_order'] as $site_key ) : ?>

--- a/tests/geographic-bridge-experiment.js
+++ b/tests/geographic-bridge-experiment.js
@@ -57,6 +57,8 @@ listener( {
 	target: control.section,
 	detail: {
 		experiment_key: 'geo-bridge-holdout',
+		definition_version: 1,
+		assignment_policy: 'weighted_random',
 		variant: 'control',
 		surface: 'single-post-bridge',
 	},
@@ -69,6 +71,8 @@ listener( {
 	target: treatment.section,
 	detail: {
 		experiment_key: 'geo-bridge-holdout',
+		definition_version: 1,
+		assignment_policy: 'weighted_random',
 		variant: 'treatment',
 		surface: 'single-post-bridge',
 	},
@@ -93,6 +97,7 @@ check( 'invalid assignments fail closed', invalid.candidateAttributes.has( 'iner
 check( 'activation emits no independent analytics requests', ! source.includes( 'fetch(' ) && ! source.includes( 'sendBeacon' ) );
 check( 'activation consumes Network assignment event', source.includes( 'extrachill:experiment-assignment' ) );
 check( 'Network retains viewport exposure ownership', ! source.includes( 'IntersectionObserver' ) );
+check( 'Network retains versioned assignment proof ownership', ! source.includes( 'exposure_token' ) );
 check( 'preassigned treatment reconciles listener timing', source.includes( 'data-ec-experiment-variant="treatment"' ) );
 
 console.log( 'Geographic bridge experiment JS tests passed.' );

--- a/tests/network-bridge.php
+++ b/tests/network-bridge.php
@@ -23,7 +23,9 @@ $test_registered_scripts   = array(
 	'extrachill-experiment-assignment'  => array( 'registered' => true ),
 	'extrachill-blog-geographic-bridge' => array(),
 );
+$test_experiment_state     = 'inactive';
 $test_experiment_available = true;
+$test_experiment_requests  = 0;
 $test_post_type            = 'post';
 $test_post_status          = 'publish';
 
@@ -110,7 +112,8 @@ function get_post_status() {
 
 /** Mirror Network's cache-neutral attribute contract. */
 function extrachill_experiment_attributes( $key, $surface, $context ) {
-	global $test_experiment_available;
+	global $test_experiment_available, $test_experiment_requests;
+	++$test_experiment_requests;
 	if ( ! $test_experiment_available ) {
 		return '';
 	}
@@ -121,6 +124,12 @@ function extrachill_experiment_attributes( $key, $surface, $context ) {
 		esc_attr( $surface ),
 		esc_attr( wp_json_encode( $context ) )
 	);
+}
+
+/** Mirror Network's lifecycle-only no-op helper. */
+function extrachill_experiment_is_active( $key ) {
+	global $test_experiment_state;
+	return 'geo-bridge-holdout' === $key && 'active' === $test_experiment_state;
 }
 
 /** Stub the shared verified resolver and capture its contract. */
@@ -220,6 +229,18 @@ $empty_output = ob_get_clean();
 assert_same( '', $empty_output, 'No-result bridges must render no empty container.' );
 
 resolve_cards( array(), array( $city_event ) );
+$test_enqueued_scripts    = array();
+$test_experiment_requests = 0;
+ob_start();
+extrachill_blog_network_bridge();
+$inactive_output = ob_get_clean();
+assert_same( true, false !== strpos( $inactive_output, 'Charleston' ), 'Inactive default must preserve the normal verified geographic bridge.' );
+assert_same( true, false === strpos( $inactive_output, 'data-ec-experiment-key' ), 'Inactive default must emit no experiment markup.' );
+assert_same( true, false === strpos( $inactive_output, 'hidden inert aria-hidden="true"' ), 'Inactive default must not hide or disable geographic links.' );
+assert_same( array(), $test_enqueued_scripts, 'Inactive default must enqueue no experiment assets.' );
+assert_same( 0, $test_experiment_requests, 'Inactive default must make no assignment attribute request.' );
+
+$test_experiment_state = 'active';
 ob_start();
 extrachill_blog_network_bridge();
 $mobile_output = ob_get_clean();
@@ -233,10 +254,15 @@ assert_same( true, false === strpos( $mobile_output, 'visitor-' ), 'Cached marku
 assert_same( true, false !== strpos( $mobile_output, 'hidden inert aria-hidden="true"' ), 'Geographic candidates must be inert and unfocusable before activation.' );
 assert_same( true, false !== strpos( $mobile_output, 'class="network-bridge-section related-tax-section"' ) && false !== strpos( $mobile_output, ' hidden>' ), 'A geography-only bridge must remain hidden in control.' );
 assert_same( true, in_array( 'extrachill-blog-geographic-bridge', $test_enqueued_scripts, true ), 'Eligible bridges should enqueue treatment activation.' );
+assert_same( 1, $test_experiment_requests, 'Active lifecycle must request Network assignment markup exactly once.' );
 assert_same( array( 'extrachill-experiment-assignment' ), $test_registered_scripts['extrachill-blog-geographic-bridge']['dependencies'], 'Viewport exposure must remain wired through Network assignment.' );
 
 $definition = extrachill_blog_register_bridge_experiment( array() );
 assert_same( array( 'geo-bridge-holdout' ), array_keys( $definition ), 'Blog should register exactly one code-owned experiment.' );
+assert_same( 'geo-bridge-holdout', $definition['geo-bridge-holdout']['key'], 'The registration key must match the stable definition key.' );
+assert_same( 1, $definition['geo-bridge-holdout']['definition_version'], 'The holdout must register definition version one.' );
+assert_same( 'weighted_random', $definition['geo-bridge-holdout']['assignment_policy'], 'The holdout must use Network weighted random allocation.' );
+assert_same( 'inactive', $definition['geo-bridge-holdout']['default_state'], 'The holdout must require explicit operator activation.' );
 assert_same(
 	array(
 		'control'   => 50,
@@ -273,5 +299,26 @@ extrachill_blog_network_bridge();
 $provider_output = ob_get_clean();
 assert_same( '', $provider_output, 'Missing or invalid experiment configuration must leave geography-only control empty.' );
 $test_experiment_available = true;
+
+foreach ( array( 'paused', 'completed' ) as $lifecycle_state ) {
+	$test_experiment_state    = $lifecycle_state;
+	$test_enqueued_scripts    = array();
+	$test_experiment_requests = 0;
+	ob_start();
+	extrachill_blog_network_bridge();
+	$lifecycle_output = ob_get_clean();
+	assert_same( true, false !== strpos( $lifecycle_output, 'Charleston' ), ucfirst( $lifecycle_state ) . ' lifecycle must preserve normal geography.' );
+	assert_same( true, false === strpos( $lifecycle_output, 'data-ec-experiment-key' ), ucfirst( $lifecycle_state ) . ' lifecycle must emit no experiment markup.' );
+	assert_same( true, false === strpos( $lifecycle_output, 'hidden inert aria-hidden="true"' ), ucfirst( $lifecycle_state ) . ' lifecycle must preserve accessible geographic links.' );
+	assert_same( array(), $test_enqueued_scripts, ucfirst( $lifecycle_state ) . ' lifecycle must enqueue no experiment assets.' );
+	assert_same( 0, $test_experiment_requests, ucfirst( $lifecycle_state ) . ' lifecycle must make no assignment attribute request.' );
+}
+
+$bridge_source = file_get_contents( dirname( __DIR__ ) . '/inc/single/network-bridge.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source inspection proves consumer layer purity.
+foreach ( array( 'get_site_option(', 'update_site_option(', 'update_option(', 'set_transient(', 'wp_cache_add(', 'wp_cache_set(', 'random_int(', 'mt_rand(', 'hash_hmac(', '$_COOKIE', 'EXTRACHILL_EXPERIMENT_LIFECYCLE_OPTION', 'extrachill_analytics', 'experiment_report', 'extrachill_experiment_assignment\'', 'extrachill_experiment_exposure\'' ) as $consumer_substrate ) {
+	assert_same( false, strpos( $bridge_source, $consumer_substrate ), 'Blog must not contain consumer-local experiment substrate: ' . $consumer_substrate );
+}
+assert_same( true, false !== strpos( $bridge_source, "add_filter( 'extrachill_experiment_definitions'" ), 'Blog must remain a definition-only Network registry consumer.' );
+assert_same( true, false !== strpos( $bridge_source, "extrachill_experiment_is_active( 'geo-bridge-holdout'" ), 'Blog lifecycle gating must use Network canonical no-op helper.' );
 
 fwrite( STDOUT, "Network bridge tests passed.\n" ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- CLI test output.


### PR DESCRIPTION
## Summary
- register `geo-bridge-holdout` through Network's canonical registry as definition version 1, `weighted_random`, inactive by default, with 50/50 control/treatment variants on `single-post-bridge`
- gate experiment markup and activation assets through Network's lifecycle-only no-op helper so inactive, paused, completed, and unavailable lifecycle support preserve the normal verified geographic bridge
- retain the active holdout's cache-neutral control candidates, Network-owned signed assignment/exposure, hidden-impression behavior, accessible treatment reveal, mobile layout, UTM links, and click instrumentation

## Lifecycle
The reviewed code default is **inactive**. Deployment therefore changes no visitor behavior and starts no experiment measurement.

An operator activates version 1 through Network's canonical `extrachill/transition-experiment-state` lifecycle Ability using `geo-bridge-holdout`, `definition_version: 1`, and `state: active`. Only that active state applies the existing 50/50 holdout. Paused and completed states immediately restore normal geographic bridge rendering with no experiment attributes, activation asset enqueue, assignment request, or experiment hook consumption.

If an active experiment cannot obtain valid Network assignment markup or its registered client dependency is absent, the existing cache-neutral control failure behavior remains in place rather than exposing treatment.

## Ownership Contract
- **Extra Chill Network #141:** owns definition validation, lifecycle state/transition storage, weighted allocation, privacy and subject handling, signed assignment/exposure proofs, trusted hooks, viewport exposure, and canonical no-op helpers
- **Extra Chill Blog:** owns only the code definition, published-post/geographic-capacity eligibility, primary artist/festival priority, verified geography resolution, and bridge rendering
- **Extra Chill Analytics #212:** consumes Network's exact five-field trusted metadata contract (`experiment_key`, `definition_version`, `assignment_policy`, `variant`, `surface`) for persistence and reporting
- **Extra Chill Users:** remains the separate authorization/rollout owner; this migration adds no consumer-local identity or access logic

Source-inspection coverage rejects consumer-local allocator, identity, persistence, lifecycle-option, trusted-hook, Analytics, or reporting primitives in Blog.

## Normal Feature Preservation
Inactive, paused, and completed lifecycle states render the same verified Events/Community geographic cards as the normal feature. Existing artist/festival destination priority, vacant-slot filling, verified Network resolver/cache path, GPC/DNT failure semantics, accessibility, responsive/mobile classes, UTM parameters, and bridge click behavior remain unchanged.

## Dependencies
- Extra-Chill/extrachill-network#141
- Extra-Chill/extrachill-analytics#212

## Verification
- `php tests/network-bridge.php`
- `node tests/geographic-bridge-experiment.js`
- `php tests/artist-dispatch.php`
- `node tests/artist-dispatch-js.js`
- `bash tests/run-artist-dispatch-integration.sh`
- changed PHP/JS syntax checks
- `vendor/bin/phpcs --standard=WordPress inc/single/network-bridge.php tests/network-bridge.php`
- `git diff --check`
- full functional `composer test` commands pass; its broad repository PHPCS tail remains blocked by pre-existing violations in unrelated files including `inc/core/co-authors.php`, `inc/core/ads-filter.php`, `inc/core/admin-customizations.php`, and `inc/single/login-register-cta.php`

Closes #73