### PR TITLE
fix: align Artist Dispatch with design system

### DIFF
--- a/assets/css/artist-dispatch.css
+++ b/assets/css/artist-dispatch.css
@@ -1,35 +1,27 @@
 .artist-dispatch-page,
 .artist-dispatch-guidelines,
 .artist-dispatch-write {
-	--dispatch-border: color-mix(in srgb, var(--text-color) 18%, transparent);
-	max-width: 920px;
+	width: 100%;
+	max-width: var(--content-width);
 	margin: 0 auto;
 }
 
 .artist-dispatch-hero {
-	padding: clamp(2.5rem, 8vw, 6rem) 0 clamp(2rem, 5vw, 4rem);
-	border-bottom: 1px solid var(--dispatch-border);
-}
-
-.artist-dispatch-hero h1,
-.artist-dispatch-guidelines h1 {
-	font-size: clamp(3rem, 9vw, 6.5rem);
-	line-height: .9;
-	letter-spacing: -.065em;
-	margin: .2em 0;
+	padding: var(--spacing-xl) 0;
+	border-bottom: 1px solid var(--border-color);
 }
 
 .artist-dispatch-hero > p:last-child,
 .artist-dispatch-guidelines header > p:last-child {
-	font-size: clamp(1.1rem, 2vw, 1.4rem);
-	max-width: 720px;
+	max-width: var(--content-width);
+	font-size: var(--font-size-lg);
 }
 
 .artist-dispatch-kicker,
 .artist-dispatch-label {
-	font-size: .75rem;
-	font-weight: 800;
-	letter-spacing: .12em;
+	font-size: var(--font-size-sm);
+	font-weight: var(--font-weight-bold);
+	letter-spacing: .08em;
 	text-transform: uppercase;
 	color: var(--accent);
 }
@@ -37,16 +29,13 @@
 .artist-dispatch-panel,
 .artist-dispatch-state,
 .artist-dispatch-dashboard {
-	margin: 2rem 0;
-	padding: clamp(1.25rem, 4vw, 2.5rem);
-	background: var(--card-background);
-	border: 1px solid var(--dispatch-border);
-	border-radius: var(--border-radius-large);
+	margin: var(--spacing-xl) 0;
+	padding: var(--spacing-lg);
 }
 
 .artist-dispatch-panel p,
 .artist-dispatch-state > p {
-	max-width: 740px;
+	max-width: var(--content-width);
 }
 
 .artist-dispatch-actions,
@@ -55,20 +44,20 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	gap: 1rem;
+	gap: var(--spacing-md);
 	flex-wrap: wrap;
 }
 
 .artist-dispatch-form {
 	display: grid;
-	gap: 1.25rem;
-	max-width: 680px;
+	gap: var(--spacing-md);
+	max-width: var(--form-width);
 }
 
-.artist-dispatch-form label:not(.artist-dispatch-check) {
+.artist-dispatch-form label:not(.ec-checkbox-row) {
 	display: grid;
-	gap: .45rem;
-	font-weight: 700;
+	gap: var(--spacing-sm);
+	font-weight: var(--font-weight-bold);
 }
 
 .artist-dispatch-form input,
@@ -76,25 +65,14 @@
 .artist-dispatch-form textarea {
 	width: 100%;
 	box-sizing: border-box;
-	padding: .8rem;
-	color: var(--text-color);
-	background: var(--body-background);
-	border: 1px solid var(--dispatch-border);
-	border-radius: var(--border-radius-small);
 }
 
 .artist-dispatch-form textarea {
-	min-height: 150px;
-}
-
-.artist-dispatch-check {
-	display: grid;
-	grid-template-columns: auto 1fr;
-	gap: .75rem;
+	min-height: 10rem;
 }
 
 .artist-dispatch-message {
-	min-height: 1.5em;
+	min-height: var(--spacing-lg);
 }
 
 .artist-dispatch-criteria,
@@ -107,28 +85,28 @@
 .artist-dispatch-group li {
 	display: flex;
 	justify-content: space-between;
-	gap: 1rem;
-	padding: .85rem 0;
-	border-bottom: 1px solid var(--dispatch-border);
+	gap: var(--spacing-md);
+	padding: var(--spacing-sm) 0;
+	border-bottom: 1px solid var(--border-color);
 }
 
 .artist-dispatch-criteria li span,
 .artist-dispatch-group li span {
 	display: block;
-	font-size: .85rem;
-	opacity: .72;
+	font-size: var(--font-size-sm);
+	color: var(--muted-text);
 }
 
 .artist-dispatch-criteria .is-met::before {
 	content: "✓";
-	color: var(--accent);
-	margin-right: .6rem;
+	color: var(--success-color);
+	margin-right: var(--spacing-sm);
 }
 
 .artist-dispatch-groups {
 	display: grid;
 	grid-template-columns: repeat(3, minmax(0, 1fr));
-	gap: 1rem;
+	gap: var(--spacing-md);
 }
 
 .artist-dispatch-group {
@@ -137,14 +115,14 @@
 
 .artist-dispatch-guidelines header,
 .artist-dispatch-guidelines section {
-	padding: clamp(1.5rem, 4vw, 3rem) 0;
-	border-bottom: 1px solid var(--dispatch-border);
+	padding: var(--spacing-xl) 0;
+	border-bottom: 1px solid var(--border-color);
 }
 
 .artist-dispatch-guidelines section {
 	display: grid;
-	grid-template-columns: minmax(180px, 1fr) 2fr;
-	gap: 2rem;
+	grid-template-columns: minmax(11rem, 1fr) 2fr;
+	gap: var(--spacing-xl);
 }
 
 .artist-dispatch-guidelines h2,
@@ -153,24 +131,21 @@
 }
 
 .artist-dispatch-write {
-	max-width: 1100px;
+	max-width: var(--container-width);
 }
 
 .artist-dispatch-write__intro {
-	padding: 1rem 0;
+	padding: var(--spacing-md) 0;
 }
 
 .artist-dispatch-editor {
 	min-height: 70vh;
-	background: var(--card-background);
-	border: 1px solid var(--dispatch-border);
-	border-radius: var(--border-radius-large);
 	overflow: hidden;
 }
 
 .artist-dispatch-editor-title {
 	width: 100%;
-	padding: 1rem clamp(1rem, 4vw, 3rem) 0;
+	padding: var(--spacing-md) var(--spacing-lg) 0;
 	box-sizing: border-box;
 }
 
@@ -181,26 +156,23 @@
 .artist-dispatch-save-state {
 	display: inline-flex;
 	align-items: center;
-	gap: .4rem;
+	gap: var(--spacing-xs);
 	margin-right: auto;
 }
 
 .artist-dispatch-disclosure {
-	padding: 1rem 1.25rem;
-	margin-bottom: 2rem;
-	background: var(--card-background);
-	border-left: 4px solid var(--accent);
+	margin-bottom: var(--spacing-xl);
 }
 
 .artist-dispatch-disclosure p {
-	margin: .35rem 0 0;
+	margin: var(--spacing-xs) 0 0;
 }
 
-@media (max-width: 720px) {
+@media (max-width: 768px) {
 	.artist-dispatch-groups,
 	.artist-dispatch-guidelines section {
 		grid-template-columns: 1fr;
-		gap: .5rem;
+		gap: var(--spacing-sm);
 	}
 
 	.artist-dispatch-dashboard__head {

--- a/inc/submit/pages.php
+++ b/inc/submit/pages.php
@@ -188,7 +188,7 @@ add_action( 'wp_enqueue_scripts', 'extrachill_blog_dispatch_enqueue_assets', 30 
  * @return string HTML.
  */
 function extrachill_blog_dispatch_intro_html() {
-	return '<header class="artist-dispatch-hero"><p class="artist-dispatch-kicker">' . esc_html__( 'From the people making the music', 'extrachill-blog' ) . '</p><h1>' . esc_html__( 'Artist Dispatch', 'extrachill-blog' ) . '</h1><p>' . esc_html__( 'Tell the real story behind your music in your own voice, with Extra Chill editorial review and a permanent main-site byline.', 'extrachill-blog' ) . '</p></header><section class="artist-dispatch-panel"><h2>' . esc_html__( 'A publication lane, not a promo form', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Forum posting is open to the community. Artist Dispatch is a scarce pathway into the Extra Chill publication for transparent first-person release stories, studio diaries, tour journals, scene reports, production breakdowns, and lessons from independent music work.', 'extrachill-blog' ) . '</p><p>' . esc_html__( 'It is not self-publishing, freelance hiring, a review of yourself, fake third-person reporting, or a place to paste a press release. Every Dispatch is reviewed by an editor before publication.', 'extrachill-blog' ) . '</p><a class="button-2" href="' . esc_url( home_url( '/submit/guidelines/' ) ) . '">' . esc_html__( 'Read the guidelines', 'extrachill-blog' ) . '</a></section>';
+	return '<header class="artist-dispatch-hero"><p class="artist-dispatch-kicker">' . esc_html__( 'From the people making the music', 'extrachill-blog' ) . '</p><h1>' . esc_html__( 'Artist Dispatch', 'extrachill-blog' ) . '</h1><p>' . esc_html__( 'Tell the real story behind your music in your own voice, with Extra Chill editorial review and a permanent main-site byline.', 'extrachill-blog' ) . '</p></header><section class="artist-dispatch-panel ec-surface-card ec-mobile-full-width-panel"><h2>' . esc_html__( 'A publication lane, not a promo form', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Forum posting is open to the community. Artist Dispatch is a scarce pathway into the Extra Chill publication for transparent first-person release stories, studio diaries, tour journals, scene reports, production breakdowns, and lessons from independent music work.', 'extrachill-blog' ) . '</p><p>' . esc_html__( 'It is not self-publishing, freelance hiring, a review of yourself, fake third-person reporting, or a place to paste a press release. Every Dispatch is reviewed by an editor before publication.', 'extrachill-blog' ) . '</p><a class="button-2 button-medium" href="' . esc_url( home_url( '/submit/guidelines/' ) ) . '">' . esc_html__( 'Read the guidelines', 'extrachill-blog' ) . '</a></section>';
 }
 
 /**
@@ -199,7 +199,7 @@ function extrachill_blog_dispatch_intro_html() {
 function extrachill_blog_dispatch_logged_out_html() {
 	$login = wp_login_url( home_url( '/submit/' ) );
 	$join  = function_exists( 'ec_get_site_url' ) ? trailingslashit( ec_get_site_url( 'community' ) ) . 'join/' : 'https://community.extrachill.com/join/';
-	return '<section class="artist-dispatch-state"><h2>' . esc_html__( 'Build your voice in the community', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Log in to check your Artist Dispatch eligibility, or join the community and start participating in the online music scene.', 'extrachill-blog' ) . '</p><div class="artist-dispatch-actions"><a class="button-1" href="' . esc_url( $login ) . '">' . esc_html__( 'Log in', 'extrachill-blog' ) . '</a><a class="button-2" href="' . esc_url( $join ) . '">' . esc_html__( 'Join the community', 'extrachill-blog' ) . '</a></div></section>';
+	return '<section class="artist-dispatch-state ec-surface-card ec-mobile-full-width-panel"><h2>' . esc_html__( 'Build your voice in the community', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Log in to check your Artist Dispatch eligibility, or join the community and start participating in the online music scene.', 'extrachill-blog' ) . '</p><div class="artist-dispatch-actions"><a class="button-1 button-medium" href="' . esc_url( $login ) . '">' . esc_html__( 'Log in', 'extrachill-blog' ) . '</a><a class="button-2 button-medium" href="' . esc_url( $join ) . '">' . esc_html__( 'Join the community', 'extrachill-blog' ) . '</a></div></section>';
 }
 
 /**
@@ -269,12 +269,12 @@ function extrachill_blog_dispatch_request_html( $access ) {
 		$options .= '<option value="' . esc_attr( $artist_id ) . '">' . esc_html( $artist['name'] ) . '</option>';
 	}
 	if ( '' === $options ) {
-		return '<section class="artist-dispatch-state is-closed"><h2>' . esc_html__( 'A represented artist is required', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Connect your account to a canonical Artist Platform profile before requesting Artist Dispatch access.', 'extrachill-blog' ) . '</p></section>';
+		return '<section class="artist-dispatch-state ec-surface-card ec-mobile-full-width-panel is-closed"><h2>' . esc_html__( 'A represented artist is required', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Connect your account to a canonical Artist Platform profile before requesting Artist Dispatch access.', 'extrachill-blog' ) . '</p></section>';
 	}
 
 	/* translators: %s: Artist Dispatch guidelines URL. */
 	$acknowledgement = sprintf( wp_kses_post( __( 'I have read the <a href="%s">Artist Dispatch guidelines</a>, disclosed my relationship to the project, and accept the rights and editorial terms.', 'extrachill-blog' ) ), esc_url( home_url( '/submit/guidelines/' ) ) );
-	return '<section class="artist-dispatch-state"><h2>' . esc_html__( 'Request Artist Dispatch access', 'extrachill-blog' ) . '</h2><form id="artist-dispatch-request" class="artist-dispatch-form"><label>' . esc_html__( 'Artist or project you represent', 'extrachill-blog' ) . '<select name="artist_id" required>' . $options . '</select></label><label>' . esc_html__( 'What story do you want to tell?', 'extrachill-blog' ) . '<textarea name="description" minlength="50" maxlength="2000" required></textarea></label><label>' . esc_html__( 'Optional sample or reference URL', 'extrachill-blog' ) . '<input type="url" name="sample_url"></label><label class="artist-dispatch-check"><input type="checkbox" name="acknowledgement" required><span>' . $acknowledgement . '</span></label><button class="button-1" type="submit">' . esc_html__( 'Request access', 'extrachill-blog' ) . '</button><p class="artist-dispatch-message" aria-live="polite"></p></form></section>';
+	return '<section class="artist-dispatch-state ec-surface-card ec-mobile-full-width-panel"><h2>' . esc_html__( 'Request Artist Dispatch access', 'extrachill-blog' ) . '</h2><form id="artist-dispatch-request" class="artist-dispatch-form"><label>' . esc_html__( 'Artist or project you represent', 'extrachill-blog' ) . '<select name="artist_id" required>' . $options . '</select></label><label>' . esc_html__( 'What story do you want to tell?', 'extrachill-blog' ) . '<textarea name="description" minlength="50" maxlength="2000" required></textarea></label><label>' . esc_html__( 'Optional sample or reference URL', 'extrachill-blog' ) . '<input type="url" name="sample_url"></label><label class="ec-checkbox-row"><input type="checkbox" name="acknowledgement" required><span>' . $acknowledgement . '</span></label><button class="button-1 button-medium" type="submit">' . esc_html__( 'Request access', 'extrachill-blog' ) . '</button><p class="artist-dispatch-message" aria-live="polite"></p></form></section>';
 }
 
 /**
@@ -341,7 +341,7 @@ function extrachill_blog_dispatch_group_html( $title, $posts, $editable = false 
 function extrachill_blog_dispatch_dashboard_html( $access ) {
 	$groups    = extrachill_blog_dispatch_dashboard_posts();
 	$artist_id = absint( isset( $access['artist_id'] ) ? $access['artist_id'] : 0 );
-	return '<section class="artist-dispatch-dashboard"><div class="artist-dispatch-dashboard__head"><div><p class="artist-dispatch-kicker">' . esc_html__( 'Approved contributor', 'extrachill-blog' ) . '</p><h2>' . esc_html__( 'Your Artist Dispatches', 'extrachill-blog' ) . '</h2></div><button id="artist-dispatch-new" class="button-1" type="button" data-artist="' . esc_attr( $artist_id ) . '">' . esc_html__( 'New Artist Dispatch', 'extrachill-blog' ) . '</button></div><p id="artist-dispatch-new-message" class="artist-dispatch-message" aria-live="polite"></p><div class="artist-dispatch-groups">' . extrachill_blog_dispatch_group_html( __( 'Drafts', 'extrachill-blog' ), $groups['draft'], true ) . extrachill_blog_dispatch_group_html( __( 'Awaiting Review', 'extrachill-blog' ), $groups['pending'] ) . extrachill_blog_dispatch_group_html( __( 'Published', 'extrachill-blog' ), $groups['publish'] ) . '</div></section>';
+	return '<section class="artist-dispatch-dashboard ec-surface-card ec-mobile-full-width-panel"><div class="artist-dispatch-dashboard__head"><div><p class="artist-dispatch-kicker">' . esc_html__( 'Approved contributor', 'extrachill-blog' ) . '</p><h2>' . esc_html__( 'Your Artist Dispatches', 'extrachill-blog' ) . '</h2></div><button id="artist-dispatch-new" class="button-1 button-medium" type="button" data-artist="' . esc_attr( $artist_id ) . '">' . esc_html__( 'New Artist Dispatch', 'extrachill-blog' ) . '</button></div><p id="artist-dispatch-new-message" class="artist-dispatch-message" aria-live="polite"></p><div class="artist-dispatch-groups">' . extrachill_blog_dispatch_group_html( __( 'Drafts', 'extrachill-blog' ), $groups['draft'], true ) . extrachill_blog_dispatch_group_html( __( 'Awaiting Review', 'extrachill-blog' ), $groups['pending'] ) . extrachill_blog_dispatch_group_html( __( 'Published', 'extrachill-blog' ), $groups['publish'] ) . '</div></section>';
 }
 
 /**
@@ -355,34 +355,34 @@ function extrachill_blog_dispatch_state_html() {
 	}
 	$access = extrachill_blog_dispatch_access();
 	if ( is_wp_error( $access ) || empty( $access['eligibility']['policy']['pilot_enabled'] ) ) {
-		return '<section class="artist-dispatch-state is-closed"><h2>' . esc_html__( 'Artist Dispatch is not accepting requests', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'The pilot is currently unavailable. Your account and community access are unaffected.', 'extrachill-blog' ) . '</p></section>';
+		return '<section class="artist-dispatch-state ec-surface-card ec-mobile-full-width-panel is-closed"><h2>' . esc_html__( 'Artist Dispatch is not accepting requests', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'The pilot is currently unavailable. Your account and community access are unaffected.', 'extrachill-blog' ) . '</p></section>';
 	}
 
 	switch ( $access['status'] ) {
 		case 'approved':
 			if ( ! extrachill_blog_dispatch_is_approved( $access ) ) {
-				return '<section class="artist-dispatch-state is-closed"><h2>' . esc_html__( 'Writing access unavailable', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Your approval is recorded, but the required native writing role is unavailable. An editor has been asked to review it.', 'extrachill-blog' ) . '</p></section>';
+				return '<section class="artist-dispatch-state ec-surface-card ec-mobile-full-width-panel is-closed"><h2>' . esc_html__( 'Writing access unavailable', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Your approval is recorded, but the required native writing role is unavailable. An editor has been asked to review it.', 'extrachill-blog' ) . '</p></section>';
 			}
 			if ( ! extrachill_blog_dispatch_has_current_terms( $access ) ) {
-				return '<section class="artist-dispatch-state is-closed"><h2>' . esc_html__( 'Current terms acceptance required', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'The audited Artist Dispatch request does not include the current guidelines and affiliation acknowledgement. Submit a current request before writing.', 'extrachill-blog' ) . '</p></section>';
+				return '<section class="artist-dispatch-state ec-surface-card ec-mobile-full-width-panel is-closed"><h2>' . esc_html__( 'Current terms acceptance required', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'The audited Artist Dispatch request does not include the current guidelines and affiliation acknowledgement. Submit a current request before writing.', 'extrachill-blog' ) . '</p></section>';
 			}
 			if ( ! extrachill_blog_dispatch_has_editor_dependency() ) {
-				return '<section class="artist-dispatch-state is-closed"><h2>' . esc_html__( 'Writing editor unavailable', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Blocks Everywhere 3.6.0 or newer must be active before a new Artist Dispatch can be started.', 'extrachill-blog' ) . '</p></section>';
+				return '<section class="artist-dispatch-state ec-surface-card ec-mobile-full-width-panel is-closed"><h2>' . esc_html__( 'Writing editor unavailable', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Blocks Everywhere 3.6.0 or newer must be active before a new Artist Dispatch can be started.', 'extrachill-blog' ) . '</p></section>';
 			}
 			return extrachill_blog_dispatch_dashboard_html( $access );
 		case 'pending':
-			return '<section class="artist-dispatch-state"><h2>' . esc_html__( 'Your request is under review', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'An Extra Chill editor will review your represented artist and proposed story. Approval opens the writing dashboard; it does not guarantee publication.', 'extrachill-blog' ) . '</p></section>';
+			return '<section class="artist-dispatch-state ec-surface-card ec-mobile-full-width-panel"><h2>' . esc_html__( 'Your request is under review', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'An Extra Chill editor will review your represented artist and proposed story. Approval opens the writing dashboard; it does not guarantee publication.', 'extrachill-blog' ) . '</p></section>';
 		case 'rejected':
-			return '<section class="artist-dispatch-state"><h2>' . esc_html__( 'Your request was not approved', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Keep participating and refining the first-person story you want to tell. If reapplication is available, the unmet criteria below will update.', 'extrachill-blog' ) . '</p>' . extrachill_blog_dispatch_criteria_html( isset( $access['eligibility'] ) ? $access['eligibility'] : array() ) . '</section>';
+			return '<section class="artist-dispatch-state ec-surface-card ec-mobile-full-width-panel"><h2>' . esc_html__( 'Your request was not approved', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Keep participating and refining the first-person story you want to tell. If reapplication is available, the unmet criteria below will update.', 'extrachill-blog' ) . '</p>' . extrachill_blog_dispatch_criteria_html( isset( $access['eligibility'] ) ? $access['eligibility'] : array() ) . '</section>';
 		case 'revoked':
 		case 'moderated':
-			return '<section class="artist-dispatch-state is-closed"><h2>' . esc_html__( 'Artist Dispatch access is unavailable', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'This account cannot use the submission pathway right now. Existing published work is unaffected.', 'extrachill-blog' ) . '</p></section>';
+			return '<section class="artist-dispatch-state ec-surface-card ec-mobile-full-width-panel is-closed"><h2>' . esc_html__( 'Artist Dispatch access is unavailable', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'This account cannot use the submission pathway right now. Existing published work is unaffected.', 'extrachill-blog' ) . '</p></section>';
 		default:
 			$eligibility = isset( $access['eligibility'] ) ? $access['eligibility'] : array();
 			if ( ! empty( $eligibility['eligible'] ) ) {
 				return extrachill_blog_dispatch_request_html( $access );
 			}
-			return '<section class="artist-dispatch-state"><h2>' . esc_html__( 'Keep building trust in the community', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Artist Dispatch access is earned through a complete account, good moderation standing, meaningful participation, and a verified relationship to an artist project.', 'extrachill-blog' ) . '</p>' . extrachill_blog_dispatch_criteria_html( $eligibility ) . '</section>';
+			return '<section class="artist-dispatch-state ec-surface-card ec-mobile-full-width-panel"><h2>' . esc_html__( 'Keep building trust in the community', 'extrachill-blog' ) . '</h2><p>' . esc_html__( 'Artist Dispatch access is earned through a complete account, good moderation standing, meaningful participation, and a verified relationship to an artist project.', 'extrachill-blog' ) . '</p>' . extrachill_blog_dispatch_criteria_html( $eligibility ) . '</section>';
 	}
 }
 
@@ -413,7 +413,7 @@ function extrachill_blog_dispatch_editor_html() {
 	if ( ! $post instanceof WP_Post ) {
 		return '';
 	}
-	return '<div class="artist-dispatch-write"><div class="artist-dispatch-write__intro"><a href="' . esc_url( home_url( '/submit/' ) ) . '">← ' . esc_html__( 'Your Dispatches', 'extrachill-blog' ) . '</a><p>' . esc_html__( 'Draft privately, preview through the real Extra Chill theme, then submit to the editorial queue.', 'extrachill-blog' ) . '</p></div><div class="artist-dispatch-editor"><textarea id="artist-dispatch-content" class="wp-editor-area">' . esc_textarea( $post->post_content ) . '</textarea></div></div>';
+	return '<div class="artist-dispatch-write"><div class="artist-dispatch-write__intro"><a href="' . esc_url( home_url( '/submit/' ) ) . '">← ' . esc_html__( 'Your Dispatches', 'extrachill-blog' ) . '</a><p>' . esc_html__( 'Draft privately, preview through the real Extra Chill theme, then submit to the editorial queue.', 'extrachill-blog' ) . '</p></div><div class="artist-dispatch-editor ec-surface-card ec-mobile-full-width-panel"><textarea id="artist-dispatch-content" class="wp-editor-area">' . esc_textarea( $post->post_content ) . '</textarea></div></div>';
 }
 
 /**

--- a/inc/submit/presentation.php
+++ b/inc/submit/presentation.php
@@ -73,7 +73,7 @@ function extrachill_blog_dispatch_disclosure_html( $post_id ) {
 			esc_url( $artist['url'] )
 		);
 	}
-	$notice = '<aside class="artist-dispatch-disclosure" aria-label="' . esc_attr__( 'Artist Dispatch disclosure', 'extrachill-blog' ) . '"><span class="artist-dispatch-label">' . esc_html__( 'Artist Dispatch', 'extrachill-blog' ) . '</span><p>' . $disclosure . '</p></aside>';
+	$notice = '<aside class="artist-dispatch-disclosure notice notice-info" aria-label="' . esc_attr__( 'Artist Dispatch disclosure', 'extrachill-blog' ) . '"><span class="artist-dispatch-label">' . esc_html__( 'Artist Dispatch', 'extrachill-blog' ) . '</span><p>' . $disclosure . '</p></aside>';
 
 	return $notice;
 }

--- a/tests/artist-dispatch.php
+++ b/tests/artist-dispatch.php
@@ -123,9 +123,14 @@ check('provisioning is idempotent and preserves existing pages', $first_pages ==
 $GLOBALS['dispatch_pages']['submit']->post_content = 'Human content';
 check('human-edited page is no longer claimed or overwritten', 0 === extrachill_blog_provision_submit_page('submit', 'Artist Dispatch', EXTRACHILL_BLOG_DISPATCH_PAGES['submit']['sentinel']));
 $GLOBALS['dispatch_pages']['submit']->post_content = EXTRACHILL_BLOG_DISPATCH_PAGES['submit']['sentinel'];
+$dispatch_css = file_get_contents( dirname( __DIR__ ) . '/assets/css/artist-dispatch.css' );
+check('feature CSS uses canonical design tokens', false === strpos($dispatch_css, '--dispatch-') && false === strpos($dispatch_css, '--border-radius-large') && false !== strpos($dispatch_css, 'var(--spacing-lg)'));
+check('intro uses canonical surface and button primitives', false !== strpos(extrachill_blog_dispatch_intro_html(), 'ec-surface-card') && false !== strpos(extrachill_blog_dispatch_intro_html(), 'button-medium'));
 
 $GLOBALS['dispatch_logged_in'] = false;
-check('logged-out cohort has login and community actions', false !== strpos(extrachill_blog_dispatch_state_html(), 'Join the community'));
+$logged_out_state = extrachill_blog_dispatch_state_html();
+check('logged-out cohort has login and community actions', false !== strpos($logged_out_state, 'Join the community'));
+check('logged-out cohort uses canonical surface primitives', false !== strpos($logged_out_state, 'ec-surface-card') && false !== strpos($logged_out_state, 'button-medium'));
 $GLOBALS['dispatch_logged_in'] = true;
 $GLOBALS['dispatch_ability'] = null;
 check('missing Users ability fails closed', false !== strpos(extrachill_blog_dispatch_state_html(), 'not accepting requests'));
@@ -143,8 +148,10 @@ $eligible['eligibility']['eligible'] = true;
 $eligible['eligibility']['criteria']['claimed_artist'] = array('passed' => true, 'artist_ids' => array(22));
 $GLOBALS['dispatch_ability'] = $eligible;
 check('eligible cohort consumes canonical artist IDs from owner contract', false !== strpos(extrachill_blog_dispatch_state_html(), 'value="22"'));
+check('request acknowledgement uses canonical checkbox primitive', false !== strpos(extrachill_blog_dispatch_state_html(), 'ec-checkbox-row'));
 $GLOBALS['dispatch_ability'] = array_merge($eligible, array('status' => 'approved', 'artist_id' => 22, 'terms_acknowledged' => true, 'terms_version' => EXTRACHILL_BLOG_DISPATCH_TERMS_VERSION));
 check('approved cohort renders native post dashboard', false !== strpos(extrachill_blog_dispatch_state_html(), 'New Artist Dispatch'));
+check('approved dashboard uses canonical surface primitive', false !== strpos(extrachill_blog_dispatch_state_html(), 'ec-surface-card'));
 $GLOBALS['dispatch_ability']['eligibility']['policy']['pilot_enabled'] = false;
 check('disabled pilot fails closed for approved state', false !== strpos(extrachill_blog_dispatch_state_html(), 'not accepting requests'));
 


### PR DESCRIPTION
## Summary
- replace feature-local card, notice, checkbox, button, border, spacing, and typography styles with canonical Extra Chill primitives and tokens
- retain only Artist Dispatch-specific page, grid, form, and editor layout CSS
- remove invalid radius token names and arbitrary fluid hero typography

## Verification
- focused Artist Dispatch PHP tests pass
- focused Artist Dispatch JavaScript tests pass
- production-file PHPCS passes
- CSS regression contract rejects local dispatch tokens and invalid radius names
- git diff check passes

Closes #77