### PR TITLE
fix: remove Recently Shipped category labels

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -593,19 +593,6 @@
     outline: none;
 }
 
-.home-shipped-type {
-    flex-shrink: 0;
-    font-size: var(--font-size-xs);
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--accent);
-    border: 1px solid var(--accent);
-    border-radius: var(--border-radius-sm);
-    padding: 0.15em 0.55em;
-    white-space: nowrap;
-}
-
 .home-shipped-main {
     display: flex;
     align-items: baseline;

--- a/inc/home/homepage-queries.php
+++ b/inc/home/homepage-queries.php
@@ -299,7 +299,6 @@ function extrachill_blog_fetch_recently_shipped() {
 			'summary'      => extrachill_blog_summarize_release_body( $release['body'] ?? '' ),
 			'published_at' => strtotime( $release['published_at'] ),
 			'url'          => $release['html_url'],
-			'type'         => extrachill_blog_classify_shipped_repo( $repo_name ),
 		);
 	}
 
@@ -396,38 +395,6 @@ function extrachill_blog_truncate_summary( $text, $length ) {
 	}
 
 	return rtrim( $truncated, " \t\n\r\0\x0B.,;:-" ) . '…';
-}
-
-/**
- * Classify a repo name into a display "type" badge via a filterable
- * prefix map. Vendor/repo-specific names live only in this config map,
- * never hardcoded in the template.
- *
- * @param string $repo_name GitHub repo name.
- * @return string Type label: platform, agents, orchestration, or tools.
- */
-function extrachill_blog_classify_shipped_repo( $repo_name ) {
-	$default_map = array(
-		'extrachill-'  => 'platform',
-		'data-machine' => 'agents',
-		'homeboy'      => 'orchestration',
-	);
-
-	/**
-	 * Filter the repo-name-prefix => type-label map used to classify
-	 * Recently Shipped rows.
-	 *
-	 * @param array<string,string> $default_map Prefix => type label.
-	 */
-	$map = apply_filters( 'extrachill_blog_shipped_type_map', $default_map );
-
-	foreach ( $map as $prefix => $type ) {
-		if ( 0 === strpos( $repo_name, $prefix ) ) {
-			return $type;
-		}
-	}
-
-	return 'tools';
 }
 
 /**

--- a/inc/home/templates/section-recently-shipped.php
+++ b/inc/home/templates/section-recently-shipped.php
@@ -31,7 +31,6 @@ $repos_total             = $recently_shipped['repos_total'];
 				rel="noopener"
 				aria-label="<?php echo esc_attr( sprintf( '%s %s', $release['repo'], $release['tag'] ) ); ?>"
 			>
-				<span class="home-shipped-type home-shipped-type-<?php echo esc_attr( $release['type'] ); ?>"><?php echo esc_html( $release['type'] ); ?></span>
 				<span class="home-shipped-main">
 					<span class="home-shipped-repo"><?php echo esc_html( $release['repo'] ); ?></span>
 					<span class="home-shipped-tag"><?php echo esc_html( $release['tag'] ); ?></span>


### PR DESCRIPTION
## Summary
- keep the Recently Shipped release listing and all useful release metadata
- remove the hardcoded repository category classifier and rendered badges
- remove the now-unused badge styling

## Verification
- `php -l inc/home/homepage-queries.php`
- `php -l inc/home/templates/section-recently-shipped.php`
- `vendor/bin/phpcs --standard=WordPress inc/home/homepage-queries.php inc/home/templates/section-recently-shipped.php`
- Functional test suite passes; repository-wide PHPCS still reports pre-existing violations in unrelated files.

Closes #81