### PR TITLE
fix: simplify Recently Shipped release rows

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -574,10 +574,10 @@
 }
 
 .home-shipped-row {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
-    flex-wrap: wrap;
-    gap: var(--spacing-xs) var(--spacing-sm);
+    gap: var(--spacing-sm);
     padding: var(--spacing-sm);
     background: var(--background-color);
     border-radius: var(--border-radius-lg);
@@ -596,9 +596,7 @@
 .home-shipped-main {
     display: flex;
     align-items: baseline;
-    flex-wrap: wrap;
-    gap: 0 var(--spacing-sm);
-    flex: 1 1 55%;
+    gap: var(--spacing-sm);
     min-width: 0;
 }
 
@@ -606,17 +604,15 @@
     font-family: var(--font-family-heading);
     font-weight: 700;
     color: var(--link-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .home-shipped-tag {
+    flex-shrink: 0;
     font-size: var(--font-size-sm);
     color: var(--muted-text);
-}
-
-.home-shipped-summary {
-    font-size: var(--font-size-sm);
-    color: var(--muted-text);
-    flex-basis: 100%;
 }
 
 .home-shipped-meta {
@@ -624,7 +620,6 @@
     font-size: var(--font-size-sm);
     color: var(--muted-text);
     white-space: nowrap;
-    margin-left: auto;
 }
 
 .home-shipped-footer {

--- a/inc/home/homepage-queries.php
+++ b/inc/home/homepage-queries.php
@@ -296,7 +296,6 @@ function extrachill_blog_fetch_recently_shipped() {
 		$releases[] = array(
 			'repo'         => $repo_name,
 			'tag'          => $release['tag_name'],
-			'summary'      => extrachill_blog_summarize_release_body( $release['body'] ?? '' ),
 			'published_at' => strtotime( $release['published_at'] ),
 			'url'          => $release['html_url'],
 		);
@@ -320,81 +319,6 @@ function extrachill_blog_fetch_recently_shipped() {
 		'repos_active_this_month' => $repos_active_this_month,
 		'repos_total'             => $repos_total,
 	);
-}
-
-/**
- * Reduce a GitHub release body to a single-line, markdown-stripped summary.
- *
- * Takes the first meaningful bullet/line of the release body (homeboy
- * writes "## What's Changed" + conventional-commit bullets), strips
- * markdown link syntax and PR references, and truncates to ~80 chars.
- *
- * @param string $body Raw release body (markdown).
- * @return string Plain-text summary, empty string if nothing usable.
- */
-function extrachill_blog_summarize_release_body( $body ) {
-	if ( '' === trim( $body ) ) {
-		return '';
-	}
-
-	$lines = preg_split( '/\r\n|\r|\n/', $body );
-	if ( false === $lines ) {
-		return '';
-	}
-
-	foreach ( $lines as $line ) {
-		$line = trim( $line );
-
-		// Skip empty lines, headings, and the auto-generated changelog footer.
-		if ( '' === $line || '#' === substr( $line, 0, 1 ) || false !== stripos( $line, 'Full Changelog' ) ) {
-			continue;
-		}
-
-		// Strip leading bullet markers.
-		$line = preg_replace( '/^[-*]\s*/', '', $line );
-
-		// Strip trailing "by @user in <PR URL>" attribution.
-		$line = preg_replace( '/\s+by\s+@\S+\s+in\s+https?:\/\/\S+\s*$/i', '', $line );
-
-		// Strip markdown links, keeping the link text: [text](url) => text.
-		$line = preg_replace( '/\[([^\]]+)\]\([^)]+\)/', '$1', $line );
-
-		// Strip bare URLs and stray markdown emphasis characters.
-		$line = preg_replace( '/https?:\/\/\S+/', '', $line );
-		$line = preg_replace( '/[`*_]/', '', $line );
-		$line = trim( $line );
-
-		if ( '' === $line ) {
-			continue;
-		}
-
-		return extrachill_blog_truncate_summary( $line, 80 );
-	}
-
-	return '';
-}
-
-/**
- * Truncate a summary string to an approximate character length on a
- * word boundary, appending an ellipsis when truncated.
- *
- * @param string $text   Source text.
- * @param int    $length Approximate max length.
- * @return string Truncated text.
- */
-function extrachill_blog_truncate_summary( $text, $length ) {
-	if ( strlen( $text ) <= $length ) {
-		return $text;
-	}
-
-	$truncated = substr( $text, 0, $length );
-	$space_pos = strrpos( $truncated, ' ' );
-
-	if ( false !== $space_pos ) {
-		$truncated = substr( $truncated, 0, $space_pos );
-	}
-
-	return rtrim( $truncated, " \t\n\r\0\x0B.,;:-" ) . '…';
 }
 
 /**

--- a/inc/home/templates/section-recently-shipped.php
+++ b/inc/home/templates/section-recently-shipped.php
@@ -34,9 +34,6 @@ $repos_total             = $recently_shipped['repos_total'];
 				<span class="home-shipped-main">
 					<span class="home-shipped-repo"><?php echo esc_html( $release['repo'] ); ?></span>
 					<span class="home-shipped-tag"><?php echo esc_html( $release['tag'] ); ?></span>
-					<?php if ( ! empty( $release['summary'] ) ) : ?>
-						<span class="home-shipped-summary"><?php echo esc_html( $release['summary'] ); ?></span>
-					<?php endif; ?>
 				</span>
 				<span class="home-shipped-meta">
 					<?php


### PR DESCRIPTION
## Summary
- reduce each Recently Shipped card to repository, version, and relative timestamp
- remove release-body summary extraction and its dead parsing helpers
- use a stable single-line grid with narrow-screen truncation for long repository names

## Verification
- `php -l inc/home/homepage-queries.php`
- `php -l inc/home/templates/section-recently-shipped.php`
- `vendor/bin/phpcs --standard=WordPress inc/home/homepage-queries.php inc/home/templates/section-recently-shipped.php`
- `php tests/homepage-event-markets.php`

Closes #84