### PR TITLE
feat: add artist preference controls

### DIFF
--- a/assets/css/entity-pillar.css
+++ b/assets/css/entity-pillar.css
@@ -94,6 +94,32 @@
 	margin-bottom: 0;
 }
 
+.entity-pillar-preferences {
+	padding: 0;
+}
+
+.entity-pillar-preferences__header,
+.entity-pillar-preferences__row {
+	padding: var(--spacing-lg);
+}
+
+.entity-pillar-preferences__row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--spacing-md);
+	border-top: 1px solid var(--border-color);
+}
+
+.entity-pillar-preferences__copy h3,
+.entity-pillar-preferences__copy p {
+	margin: 0;
+}
+
+.entity-pillar-preferences__copy h3 {
+	margin-bottom: var(--spacing-xs);
+}
+
 .entity-pillar-activity {
 	margin: var(--spacing-xl) 0;
 }
@@ -170,9 +196,23 @@
 	}
 
 	.entity-pillar-route,
-	.entity-pillar-newsletter,
-	.entity-pillar-subscription {
+	.entity-pillar-newsletter {
 		padding: var(--spacing-md);
+	}
+
+	.entity-pillar-subscription:not(.entity-pillar-preferences),
+	.entity-pillar-preferences__header,
+	.entity-pillar-preferences__row {
+		padding: var(--spacing-md);
+	}
+
+	.entity-pillar-preferences__row {
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	.entity-pillar-preferences__row .button-1 {
+		align-self: flex-start;
 	}
 
 	.entity-pillar-activity-item {

--- a/assets/js/entity-subscriptions.js
+++ b/assets/js/entity-subscriptions.js
@@ -9,8 +9,8 @@
 
 	function setState( button, subscribed, message ) {
 		button.setAttribute( 'aria-pressed', subscribed ? 'true' : 'false' );
-		button.textContent = subscribed ? 'Subscribed to updates' : 'Subscribe to updates';
-		getControl( button ).querySelector( '.entity-pillar-subscription-status' ).textContent = message || '';
+		button.textContent = subscribed ? button.dataset.onLabel : button.dataset.offLabel;
+		getControl( button ).querySelector( '.entity-pillar-subscription-status' ).textContent = message || ( subscribed ? button.dataset.onStatus : button.dataset.offStatus );
 	}
 
 	function request( button, ability, method ) {
@@ -50,19 +50,18 @@
 	buttons.forEach( function ( button ) {
 		request( button, 'entity-subscription-status', 'GET' ).then( function ( data ) {
 			setState( button, Boolean( data.subscribed ) );
-		} ).catch( function () {
-			getControl( button ).querySelector( '.entity-pillar-subscription-status' ).textContent = 'Subscription status is unavailable. Please try again.';
-		} ).finally( function () {
 			button.disabled = false;
+		} ).catch( function () {
+			getControl( button ).querySelector( '.entity-pillar-subscription-status' ).textContent = "Couldn't load this setting. Refresh to try again.";
 		} );
 
 		button.addEventListener( 'click', function () {
 			const subscribed = 'true' === button.getAttribute( 'aria-pressed' );
 			button.disabled = true;
 			request( button, subscribed ? 'entity-unsubscribe' : 'entity-subscribe', 'POST' ).then( function ( data ) {
-				setState( button, Boolean( data.subscribed ), data.subscribed ? 'You will receive updates.' : 'You will no longer receive updates.' );
+				setState( button, Boolean( data.subscribed ) );
 			} ).catch( function () {
-				getControl( button ).querySelector( '.entity-pillar-subscription-status' ).textContent = 'Unable to update your subscription. Please try again.';
+				getControl( button ).querySelector( '.entity-pillar-subscription-status' ).textContent = 'Unable to update this setting. Please try again.';
 			} ).finally( function () {
 				button.disabled = false;
 			} );

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
             "php tests/newsletter-context.php",
             "php tests/network-bridge.php",
             "php tests/artist-dispatch.php",
+            "node tests/entity-subscriptions-js.js",
             "node tests/artist-dispatch-js.js",
             "node tests/geographic-bridge-experiment.js",
             "@lint:php"

--- a/inc/archive/artist-pillar.php
+++ b/inc/archive/artist-pillar.php
@@ -516,10 +516,22 @@ function extrachill_blog_render_artist_coverage_heading() {
 add_action( 'extrachill_archive_above_posts', 'extrachill_blog_render_artist_coverage_heading', 20 );
 
 /**
- * Render the private artist subscription control.
+ * Register artist email sharing independently from artist notifications.
  *
- * @return void
+ * @param array $entities Entity identity definitions.
+ * @return array
  */
+function extrachill_blog_register_artist_email_sharing_identity( $entities ) {
+	$entities['artist-email-sharing'] = array(
+		'taxonomy'                           => 'artist',
+		'uses_notification_email_preference' => false,
+	);
+
+	return $entities;
+}
+add_filter( 'extrachill_users_entity_subscription_entities', 'extrachill_blog_register_artist_email_sharing_identity' );
+
+/** Render account-owned artist preferences. */
 function extrachill_blog_render_artist_subscription_control() {
 	if ( ! extrachill_blog_is_artist_pillar() || is_paged() ) {
 		return;
@@ -532,10 +544,10 @@ function extrachill_blog_render_artist_subscription_control() {
 
 	if ( ! is_user_logged_in() ) {
 		?>
-		<section class="entity-pillar-subscription" aria-labelledby="artist-pillar-subscription-title">
-			<h2 id="artist-pillar-subscription-title"><?php esc_html_e( 'Get artist updates', 'extrachill-blog' ); ?></h2>
-			<p><?php esc_html_e( 'Log in to subscribe to private Extra Chill notifications for this artist.', 'extrachill-blog' ); ?></p>
-			<a class="button-1 button-medium entity-pillar-subscription-button" href="<?php echo esc_url( wp_login_url( get_term_link( $term ) ) ); ?>"><?php esc_html_e( 'Log in to subscribe', 'extrachill-blog' ); ?></a>
+		<section class="entity-pillar-subscription" aria-labelledby="artist-pillar-preferences-title">
+			<h2 id="artist-pillar-preferences-title"><?php esc_html_e( 'Artist preferences', 'extrachill-blog' ); ?></h2>
+			<p><?php esc_html_e( 'Get artist notifications and choose whether to share your email with this artist.', 'extrachill-blog' ); ?></p>
+			<a class="button-1 button-medium entity-pillar-subscription-button" href="<?php echo esc_url( wp_login_url( get_term_link( $term ) ) ); ?>"><?php esc_html_e( 'Log in to manage preferences', 'extrachill-blog' ); ?></a>
 		</section>
 		<?php
 		return;
@@ -543,24 +555,55 @@ function extrachill_blog_render_artist_subscription_control() {
 
 	wp_enqueue_script( 'extrachill-blog-entity-subscriptions' );
 	?>
-	<section class="entity-pillar-subscription" data-entity-subscription-control aria-labelledby="artist-pillar-subscription-title">
-		<h2 id="artist-pillar-subscription-title"><?php esc_html_e( 'Get artist updates', 'extrachill-blog' ); ?></h2>
-		<p><?php esc_html_e( 'Subscribe to private Extra Chill notifications for new editorial coverage of this artist.', 'extrachill-blog' ); ?></p>
-		<button
-			class="button-1 button-medium entity-pillar-subscription-button"
-			type="button"
-			aria-pressed="false"
-			disabled
-			data-entity-subscription
-			data-entity-type="artist"
-			data-taxonomy="artist"
-			data-slug="<?php echo esc_attr( $term->slug ); ?>"
-			data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>"
-			data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>"
-		>
-			<?php esc_html_e( 'Subscribe to updates', 'extrachill-blog' ); ?>
-		</button>
-		<p class="entity-pillar-subscription-status" aria-live="polite"></p>
+	<section class="entity-pillar-subscription entity-pillar-preferences" aria-labelledby="artist-pillar-preferences-title">
+		<div class="entity-pillar-preferences__header">
+			<h2 id="artist-pillar-preferences-title"><?php esc_html_e( 'Artist preferences', 'extrachill-blog' ); ?></h2>
+			<p><?php esc_html_e( 'Choose Extra Chill notifications and whether this artist can access your email.', 'extrachill-blog' ); ?></p>
+		</div>
+		<div class="entity-pillar-preferences__row" data-entity-subscription-control>
+			<div class="entity-pillar-preferences__copy">
+				<h3><?php esc_html_e( 'Artist notifications', 'extrachill-blog' ); ?></h3>
+				<p class="entity-pillar-subscription-status" aria-live="polite"><?php esc_html_e( 'Checking...', 'extrachill-blog' ); ?></p>
+			</div>
+			<button
+				class="button-1 button-medium entity-pillar-subscription-button"
+				type="button"
+				aria-pressed="false"
+				disabled
+				data-entity-subscription
+				data-entity-type="artist"
+				data-taxonomy="artist"
+				data-slug="<?php echo esc_attr( $term->slug ); ?>"
+				data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>"
+				data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>"
+				data-on-label="<?php esc_attr_e( 'Turn off', 'extrachill-blog' ); ?>"
+				data-off-label="<?php esc_attr_e( 'Turn on', 'extrachill-blog' ); ?>"
+				data-on-status="<?php esc_attr_e( 'On', 'extrachill-blog' ); ?>"
+				data-off-status="<?php esc_attr_e( 'Off', 'extrachill-blog' ); ?>"
+			><?php esc_html_e( 'Turn on', 'extrachill-blog' ); ?></button>
+		</div>
+		<div class="entity-pillar-preferences__row" data-entity-subscription-control>
+			<div class="entity-pillar-preferences__copy">
+				<h3><?php esc_html_e( 'Artist email list', 'extrachill-blog' ); ?></h3>
+				<p class="entity-pillar-subscription-status" aria-live="polite"><?php esc_html_e( 'Checking...', 'extrachill-blog' ); ?></p>
+			</div>
+			<button
+				class="button-1 button-medium entity-pillar-subscription-button"
+				type="button"
+				aria-pressed="false"
+				disabled
+				data-entity-subscription
+				data-entity-type="artist-email-sharing"
+				data-taxonomy="artist"
+				data-slug="<?php echo esc_attr( $term->slug ); ?>"
+				data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>"
+				data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>"
+				data-on-label="<?php esc_attr_e( 'Stop sharing', 'extrachill-blog' ); ?>"
+				data-off-label="<?php esc_attr_e( 'Share email', 'extrachill-blog' ); ?>"
+				data-on-status="<?php esc_attr_e( 'Shared with this artist', 'extrachill-blog' ); ?>"
+				data-off-status="<?php esc_attr_e( 'Not shared with this artist', 'extrachill-blog' ); ?>"
+			><?php esc_html_e( 'Share email', 'extrachill-blog' ); ?></button>
+		</div>
 	</section>
 	<?php
 }

--- a/inc/archive/artist-pillar.php
+++ b/inc/archive/artist-pillar.php
@@ -515,22 +515,6 @@ function extrachill_blog_render_artist_coverage_heading() {
 }
 add_action( 'extrachill_archive_above_posts', 'extrachill_blog_render_artist_coverage_heading', 20 );
 
-/**
- * Register artist email sharing independently from artist notifications.
- *
- * @param array $entities Entity identity definitions.
- * @return array
- */
-function extrachill_blog_register_artist_email_sharing_identity( $entities ) {
-	$entities['artist-email-sharing'] = array(
-		'taxonomy'                           => 'artist',
-		'uses_notification_email_preference' => false,
-	);
-
-	return $entities;
-}
-add_filter( 'extrachill_users_entity_subscription_entities', 'extrachill_blog_register_artist_email_sharing_identity' );
-
 /** Render account-owned artist preferences. */
 function extrachill_blog_render_artist_subscription_control() {
 	if ( ! extrachill_blog_is_artist_pillar() || is_paged() ) {

--- a/tests/artist-activity.php
+++ b/tests/artist-activity.php
@@ -90,7 +90,6 @@ assert_same( 'https://community.example.test/t/canonical-topic-42', extrachill_b
 $artist_pillar_source         = file_get_contents( dirname( __DIR__ ) . '/inc/archive/artist-pillar.php' );
 $festival_subscriptions_source = file_get_contents( dirname( __DIR__ ) . '/inc/archive/festival-subscriptions.php' );
 assert_same( 3, substr_count( $artist_pillar_source, 'class="button-1 button-medium entity-pillar-subscription-button"' ), 'Artist preference controls should use theme button classes.' );
-assert_true( false !== strpos( $artist_pillar_source, "'artist-email-sharing'" ), 'Artist preferences must register the scoped email-sharing identity.' );
 assert_true( false !== strpos( $artist_pillar_source, 'data-entity-type="artist-email-sharing"' ), 'Artist preferences must render email sharing separately from notifications.' );
 assert_true( false !== strpos( $artist_pillar_source, 'Artist preferences' ), 'Artist preferences should use one coherent heading.' );
 assert_same( 2, substr_count( $festival_subscriptions_source, 'class="button-1 button-medium entity-pillar-subscription-button"' ), 'Festival subscription controls should use theme button classes.' );

--- a/tests/artist-activity.php
+++ b/tests/artist-activity.php
@@ -89,7 +89,10 @@ assert_same( 'https://community.example.test/t/canonical-topic-42', extrachill_b
 
 $artist_pillar_source         = file_get_contents( dirname( __DIR__ ) . '/inc/archive/artist-pillar.php' );
 $festival_subscriptions_source = file_get_contents( dirname( __DIR__ ) . '/inc/archive/festival-subscriptions.php' );
-assert_same( 2, substr_count( $artist_pillar_source, 'class="button-1 button-medium entity-pillar-subscription-button"' ), 'Artist subscription controls should use theme button classes.' );
+assert_same( 3, substr_count( $artist_pillar_source, 'class="button-1 button-medium entity-pillar-subscription-button"' ), 'Artist preference controls should use theme button classes.' );
+assert_true( false !== strpos( $artist_pillar_source, "'artist-email-sharing'" ), 'Artist preferences must register the scoped email-sharing identity.' );
+assert_true( false !== strpos( $artist_pillar_source, 'data-entity-type="artist-email-sharing"' ), 'Artist preferences must render email sharing separately from notifications.' );
+assert_true( false !== strpos( $artist_pillar_source, 'Artist preferences' ), 'Artist preferences should use one coherent heading.' );
 assert_same( 2, substr_count( $festival_subscriptions_source, 'class="button-1 button-medium entity-pillar-subscription-button"' ), 'Festival subscription controls should use theme button classes.' );
 
 $sorted = extrachill_blog_sort_artist_activity(

--- a/tests/entity-subscriptions-js.js
+++ b/tests/entity-subscriptions-js.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+const assert = require( 'node:assert/strict' );
+const script = require.resolve( '../assets/js/entity-subscriptions.js' );
+
+function makeButton( dataset ) {
+	const status = { textContent: 'Checking...' };
+	const attributes = { 'aria-pressed': 'false' };
+	const button = {
+		dataset,
+		disabled: true,
+		textContent: dataset.offLabel,
+		setAttribute: ( key, value ) => {
+			attributes[ key ] = value;
+		},
+		getAttribute: ( key ) => attributes[ key ],
+		closest: () => ( {
+			querySelector: () => status,
+		} ),
+		addEventListener: ( event, callback ) => {
+			button.listeners[ event ] = callback;
+		},
+		listeners: {},
+		status,
+	};
+
+	return button;
+}
+
+function flushPromises() {
+	return new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+}
+
+async function loadScript( buttons, fetch ) {
+	global.document = { querySelectorAll: () => buttons };
+	global.fetch = fetch;
+	global.window = { fetch };
+	delete require.cache[ script ];
+	require( script );
+	await flushPromises();
+}
+
+( async () => {
+	const shared = {
+		taxonomy: 'artist',
+		slug: 'susto',
+		endpoint: 'https://example.test/wp-json/wp-abilities/v1/abilities/',
+		nonce: 'nonce',
+	};
+	const notifications = makeButton( {
+		...shared,
+		entityType: 'artist',
+		onLabel: 'Turn off',
+		offLabel: 'Turn on',
+		onStatus: 'On',
+		offStatus: 'Off',
+	} );
+	const email = makeButton( {
+		...shared,
+		entityType: 'artist-email-sharing',
+		onLabel: 'Stop sharing',
+		offLabel: 'Share email',
+		onStatus: 'Shared with this artist',
+		offStatus: 'Not shared with this artist',
+	} );
+	let request = 0;
+
+	await loadScript( [ notifications, email ], () => {
+		const current = ++request;
+		return Promise.resolve( {
+			ok: true,
+			json: () => Promise.resolve( { subscribed: 2 === current } ),
+		} );
+	} );
+
+	assert.equal( notifications.textContent, 'Turn on' );
+	assert.equal( notifications.status.textContent, 'Off' );
+	assert.equal( notifications.disabled, false );
+	assert.equal( email.textContent, 'Stop sharing' );
+	assert.equal( email.status.textContent, 'Shared with this artist' );
+	assert.equal( email.disabled, false );
+
+	const unavailable = makeButton( {
+		...shared,
+		entityType: 'artist-email-sharing',
+		onLabel: 'Stop sharing',
+		offLabel: 'Share email',
+		onStatus: 'Shared with this artist',
+		offStatus: 'Not shared with this artist',
+	} );
+	await loadScript( [ unavailable ], () => Promise.reject( new Error( 'offline' ) ) );
+
+	assert.equal( unavailable.disabled, true );
+	assert.equal( unavailable.status.textContent, "Couldn't load this setting. Refresh to try again." );
+
+	process.stdout.write( 'Entity subscription JavaScript tests passed.\n' );
+} )().catch( ( error ) => {
+	console.error( error );
+	process.exit( 1 );
+} );


### PR DESCRIPTION
## Summary
- compose Extra Chill artist notifications and artist email sharing in one preferences panel
- register the canonical `artist-email-sharing/artist/<slug>` identity on the Blog runtime
- keep both consent choices independent and fail closed when status cannot be loaded
- add responsive styling and focused PHP/JavaScript regression coverage

## Testing
- `node tests/entity-subscriptions-js.js`
- `node --check assets/js/entity-subscriptions.js`
- `php tests/artist-activity.php`
- `vendor/bin/phpcs --standard=WordPress inc/archive/artist-pillar.php`
- `git diff --check`

The full `composer test` executable suites pass before its final repository-wide PHPCS stage, which remains blocked by pre-existing lint debt in unrelated files.

## Boundaries

This uses Users-owned authenticated consent and does not replace or dual-write Artist Platform's direct anonymous email signup rows.

Closes #87
Closes #86