### PR TITLE
fix: collapse artist preferences into one notice

### DIFF
--- a/assets/css/entity-pillar.css
+++ b/assets/css/entity-pillar.css
@@ -95,20 +95,25 @@
 }
 
 .entity-pillar-preferences {
-	padding: 0;
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: var(--spacing-lg);
 }
 
-.entity-pillar-preferences__header,
-.entity-pillar-preferences__row {
-	padding: var(--spacing-lg);
+.entity-pillar-preferences__header {
+	min-width: 0;
 }
 
-.entity-pillar-preferences__row {
+.entity-pillar-preferences__controls,
+.entity-pillar-preferences__control {
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
 	gap: var(--spacing-md);
-	border-top: 1px solid var(--border-color);
+}
+
+.entity-pillar-preferences__controls {
+	align-items: flex-end;
 }
 
 .entity-pillar-preferences__copy h3,
@@ -200,18 +205,18 @@
 		padding: var(--spacing-md);
 	}
 
-	.entity-pillar-subscription:not(.entity-pillar-preferences),
-	.entity-pillar-preferences__header,
-	.entity-pillar-preferences__row {
+	.entity-pillar-subscription {
 		padding: var(--spacing-md);
 	}
 
-	.entity-pillar-preferences__row {
+	.entity-pillar-preferences,
+	.entity-pillar-preferences__controls,
+	.entity-pillar-preferences__control {
 		align-items: stretch;
 		flex-direction: column;
 	}
 
-	.entity-pillar-preferences__row .button-1 {
+	.entity-pillar-preferences__control .button-1 {
 		align-self: flex-start;
 	}
 

--- a/inc/archive/artist-pillar.php
+++ b/inc/archive/artist-pillar.php
@@ -525,13 +525,19 @@ function extrachill_blog_render_artist_subscription_control() {
 	if ( ! ( $term instanceof WP_Term ) ) {
 		return;
 	}
+	$docs_url = function_exists( 'ec_get_site_url' ) ? trailingslashit( ec_get_site_url( 'docs' ) ) . 'artist-platform/artist-preferences/' : '';
 
 	if ( ! is_user_logged_in() ) {
 		?>
 		<section class="entity-pillar-subscription" aria-labelledby="artist-pillar-preferences-title">
 			<h2 id="artist-pillar-preferences-title"><?php esc_html_e( 'Artist preferences', 'extrachill-blog' ); ?></h2>
-			<p><?php esc_html_e( 'Get artist notifications and choose whether to share your email with this artist.', 'extrachill-blog' ); ?></p>
-			<a class="button-1 button-medium entity-pillar-subscription-button" href="<?php echo esc_url( wp_login_url( get_term_link( $term ) ) ); ?>"><?php esc_html_e( 'Log in to manage preferences', 'extrachill-blog' ); ?></a>
+			<p>
+				<?php esc_html_e( 'Control artist alerts and email access.', 'extrachill-blog' ); ?>
+				<?php if ( $docs_url ) : ?>
+					<a href="<?php echo esc_url( $docs_url ); ?>"><?php esc_html_e( 'How preferences work', 'extrachill-blog' ); ?></a>
+				<?php endif; ?>
+			</p>
+			<a class="button-1 button-medium entity-pillar-subscription-button" href="<?php echo esc_url( wp_login_url( get_term_link( $term ) ) ); ?>"><?php esc_html_e( 'Log in to manage', 'extrachill-blog' ); ?></a>
 		</section>
 		<?php
 		return;
@@ -542,14 +548,20 @@ function extrachill_blog_render_artist_subscription_control() {
 	<section class="entity-pillar-subscription entity-pillar-preferences" aria-labelledby="artist-pillar-preferences-title">
 		<div class="entity-pillar-preferences__header">
 			<h2 id="artist-pillar-preferences-title"><?php esc_html_e( 'Artist preferences', 'extrachill-blog' ); ?></h2>
-			<p><?php esc_html_e( 'Choose Extra Chill notifications and whether this artist can access your email.', 'extrachill-blog' ); ?></p>
+			<p>
+				<?php esc_html_e( 'Control artist alerts and email access.', 'extrachill-blog' ); ?>
+				<?php if ( $docs_url ) : ?>
+					<a href="<?php echo esc_url( $docs_url ); ?>"><?php esc_html_e( 'How preferences work', 'extrachill-blog' ); ?></a>
+				<?php endif; ?>
+			</p>
 		</div>
-		<div class="entity-pillar-preferences__row" data-entity-subscription-control>
-			<div class="entity-pillar-preferences__copy">
-				<h3><?php esc_html_e( 'Artist notifications', 'extrachill-blog' ); ?></h3>
-				<p class="entity-pillar-subscription-status" aria-live="polite"><?php esc_html_e( 'Checking...', 'extrachill-blog' ); ?></p>
-			</div>
-			<button
+		<div class="entity-pillar-preferences__controls">
+			<div class="entity-pillar-preferences__control" data-entity-subscription-control>
+				<div class="entity-pillar-preferences__copy">
+					<h3><?php esc_html_e( 'Artist notifications', 'extrachill-blog' ); ?></h3>
+					<p class="entity-pillar-subscription-status" aria-live="polite"><?php esc_html_e( 'Checking...', 'extrachill-blog' ); ?></p>
+				</div>
+				<button
 				class="button-1 button-medium entity-pillar-subscription-button"
 				type="button"
 				aria-pressed="false"
@@ -564,14 +576,14 @@ function extrachill_blog_render_artist_subscription_control() {
 				data-off-label="<?php esc_attr_e( 'Turn on', 'extrachill-blog' ); ?>"
 				data-on-status="<?php esc_attr_e( 'On', 'extrachill-blog' ); ?>"
 				data-off-status="<?php esc_attr_e( 'Off', 'extrachill-blog' ); ?>"
-			><?php esc_html_e( 'Turn on', 'extrachill-blog' ); ?></button>
-		</div>
-		<div class="entity-pillar-preferences__row" data-entity-subscription-control>
-			<div class="entity-pillar-preferences__copy">
-				<h3><?php esc_html_e( 'Artist email list', 'extrachill-blog' ); ?></h3>
-				<p class="entity-pillar-subscription-status" aria-live="polite"><?php esc_html_e( 'Checking...', 'extrachill-blog' ); ?></p>
+				><?php esc_html_e( 'Turn on', 'extrachill-blog' ); ?></button>
 			</div>
-			<button
+			<div class="entity-pillar-preferences__control" data-entity-subscription-control>
+				<div class="entity-pillar-preferences__copy">
+					<h3><?php esc_html_e( 'Artist email list', 'extrachill-blog' ); ?></h3>
+					<p class="entity-pillar-subscription-status" aria-live="polite"><?php esc_html_e( 'Checking...', 'extrachill-blog' ); ?></p>
+				</div>
+				<button
 				class="button-1 button-medium entity-pillar-subscription-button"
 				type="button"
 				aria-pressed="false"
@@ -586,7 +598,8 @@ function extrachill_blog_render_artist_subscription_control() {
 				data-off-label="<?php esc_attr_e( 'Share email', 'extrachill-blog' ); ?>"
 				data-on-status="<?php esc_attr_e( 'Shared with this artist', 'extrachill-blog' ); ?>"
 				data-off-status="<?php esc_attr_e( 'Not shared with this artist', 'extrachill-blog' ); ?>"
-			><?php esc_html_e( 'Share email', 'extrachill-blog' ); ?></button>
+				><?php esc_html_e( 'Share email', 'extrachill-blog' ); ?></button>
+			</div>
 		</div>
 	</section>
 	<?php

--- a/tests/artist-activity.php
+++ b/tests/artist-activity.php
@@ -92,6 +92,8 @@ $festival_subscriptions_source = file_get_contents( dirname( __DIR__ ) . '/inc/a
 assert_same( 3, substr_count( $artist_pillar_source, 'class="button-1 button-medium entity-pillar-subscription-button"' ), 'Artist preference controls should use theme button classes.' );
 assert_true( false !== strpos( $artist_pillar_source, 'data-entity-type="artist-email-sharing"' ), 'Artist preferences must render email sharing separately from notifications.' );
 assert_true( false !== strpos( $artist_pillar_source, 'Artist preferences' ), 'Artist preferences should use one coherent heading.' );
+assert_true( false !== strpos( $artist_pillar_source, "ec_get_site_url( 'docs' )" ), 'Artist preferences should resolve documentation through the network site registry.' );
+assert_true( false === strpos( $artist_pillar_source, 'entity-pillar-preferences__row' ), 'Artist preferences should not render nested notice rows.' );
 assert_same( 2, substr_count( $festival_subscriptions_source, 'class="button-1 button-medium entity-pillar-subscription-button"' ), 'Festival subscription controls should use theme button classes.' );
 
 $sorted = extrachill_blog_sort_artist_activity(


### PR DESCRIPTION
## Summary
- flatten artist notifications and email sharing into one existing card surface
- remove nested preference rows while preserving independent consent controls
- resolve contextual help through the canonical Docs site registry

## Verification
- `php tests/artist-activity.php`
- `node tests/entity-subscriptions-js.js`
- targeted WordPress PHPCS
- `git diff --check`

## Release order
Merge and publish the linked Docs PR first so the contextual help link is live before this change deploys.

Closes #89