### PR TITLE
fix: make entity notification delivery retry-safe

### DIFF
--- a/inc/archive/festival-subscriptions.php
+++ b/inc/archive/festival-subscriptions.php
@@ -127,7 +127,7 @@ function extrachill_blog_notify_entity_subscribers( $new_status, $old_status, $p
 	}
 
 	$terms = extrachill_blog_get_post_entity_terms( $post->ID, $entity_type );
-	if ( empty( $terms ) || ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify' ) ) {
+	if ( empty( $terms ) || ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify_with_receipts' ) ) {
 		return;
 	}
 
@@ -163,22 +163,33 @@ function extrachill_blog_notify_entity_subscribers( $new_status, $old_status, $p
 		return;
 	}
 
-	// Claim before delivery so concurrent publish hooks cannot duplicate notices.
+	// Claim before delivery; canonical receipts make a released claim safe to retry.
 	if ( ! add_post_meta( $post->ID, $notified_meta, current_time( 'mysql', true ), true ) ) {
 		return;
 	}
 
-	ec_users_notify(
+	$receipt = ec_users_notify_with_receipts(
 		$recipient_ids,
 		array(
-			'actor_id' => $actor_id,
-			'type'     => $notification_type,
+			'actor_id'        => $actor_id,
+			'type'            => $notification_type,
 			/* translators: %s: post title. */
-			'title'    => sprintf( $notification_title, get_the_title( $post ) ),
-			'link'     => get_permalink( $post ),
-			'item_id'  => (int) $post->ID,
+			'title'           => sprintf( $notification_title, get_the_title( $post ) ),
+			'link'            => get_permalink( $post ),
+			'item_id'         => (int) $post->ID,
+			'producer'        => EXTRACHILL_BLOG_ENTITY_SUBSCRIPTION_PRODUCER,
+			'idempotency_key' => 'post:' . (int) $post->ID . ':' . $notification_type,
 		)
 	);
+
+	$recipient_receipts = is_array( $receipt ) && is_array( $receipt['recipients'] ?? null ) ? $receipt['recipients'] : array();
+	foreach ( $recipient_ids as $recipient_id ) {
+		$status = is_array( $recipient_receipts[ $recipient_id ] ?? null ) ? ( $recipient_receipts[ $recipient_id ]['status'] ?? '' ) : '';
+		if ( ! in_array( $status, array( 'inserted', 'existing' ), true ) ) {
+			delete_post_meta( $post->ID, $notified_meta );
+			return;
+		}
+	}
 }
 
 /**

--- a/tests/festival-subscriptions.php
+++ b/tests/festival-subscriptions.php
@@ -15,8 +15,10 @@ class WP_Term {
 	}
 }
 
-$test_meta          = array();
-$test_notifications = array();
+$test_meta             = array();
+$test_notifications    = array();
+$test_receipt_statuses = array();
+$test_invalid_receipt  = false;
 
 function add_action() {}
 function add_filter() {}
@@ -46,6 +48,10 @@ function add_post_meta( $post_id, $key, $value, $unique ) {
 	$test_meta[ $post_id ][ $key ] = $value;
 	return true;
 }
+function delete_post_meta( $post_id, $key ) {
+	global $test_meta;
+	unset( $test_meta[ $post_id ][ $key ] );
+}
 function current_time() {
 	return '2026-07-12 20:00:00';
 }
@@ -73,12 +79,34 @@ function extrachill_users_entity_subscription_recipients( $producer, $entity_typ
 	}
 	return '-one' === substr( $slug, -4 ) ? array( 4, 7 ) : array( 7, 9 );
 }
-function ec_users_notify( $recipient_ids, $data ) {
-	global $test_notifications;
+function ec_users_notify_with_receipts( $recipient_ids, $data ) {
+	global $test_invalid_receipt, $test_notifications, $test_receipt_statuses;
 	$test_notifications[] = array(
 		'recipient_ids' => $recipient_ids,
 		'data'          => $data,
 	);
+	if ( $test_invalid_receipt ) {
+		return null;
+	}
+
+	$receipt = array(
+		'inserted'   => 0,
+		'existing'   => 0,
+		'failed'     => 0,
+		'recipients' => array(),
+	);
+	foreach ( $recipient_ids as $recipient_id ) {
+		$status = $test_receipt_statuses[ $recipient_id ] ?? 'inserted';
+		++$receipt[ $status ];
+		$receipt['recipients'][ $recipient_id ] = array(
+			'user_id'         => $recipient_id,
+			'status'          => $status,
+			'notification_id' => 'failed' === $status ? null : $recipient_id + 100,
+			'error'           => 'failed' === $status ? 'insert_failed' : null,
+		);
+	}
+
+	return $receipt;
 }
 
 require_once dirname( __DIR__ ) . '/inc/archive/festival-subscriptions.php';
@@ -103,12 +131,14 @@ extrachill_blog_notify_festival_subscribers( 'publish', 'draft', $post );
 assert_same( 1, count( $test_notifications ), 'First publication should notify subscribers once.' );
 assert_same( array( 4, 7, 9 ), $test_notifications[0]['recipient_ids'], 'Recipients from multiple festival terms must be unique.' );
 assert_same( 'festival_update', $test_notifications[0]['data']['type'], 'Festival updates must use their dedicated notification type.' );
+assert_same( 'extrachill-blog', $test_notifications[0]['data']['producer'], 'Entity updates must use the Blog producer.' );
+assert_same( 'post:46:festival_update', $test_notifications[0]['data']['idempotency_key'], 'Festival delivery must use one content-level idempotency key.' );
 
 extrachill_blog_notify_festival_subscribers( 'publish', 'draft', $post );
 assert_same( 1, count( $test_notifications ), 'Publish guard must prevent duplicate notifications.' );
 
 $artist_post = (object) array(
-	'ID'          => 47,
+	'ID'          => 46,
 	'post_type'   => 'post',
 	'post_author' => 12,
 );
@@ -117,8 +147,56 @@ extrachill_blog_notify_artist_subscribers( 'publish', 'draft', $artist_post );
 assert_same( 2, count( $test_notifications ), 'First artist publication should notify subscribers once.' );
 assert_same( array( 4, 7, 9 ), $test_notifications[1]['recipient_ids'], 'Artist recipients from multiple terms must be unique.' );
 assert_same( 'artist_update', $test_notifications[1]['data']['type'], 'Artist updates must use their dedicated notification type.' );
+assert_same( 'post:46:artist_update', $test_notifications[1]['data']['idempotency_key'], 'Artist delivery must not collide with festival delivery for the same post.' );
 
 extrachill_blog_notify_artist_subscribers( 'publish', 'draft', $artist_post );
 assert_same( 2, count( $test_notifications ), 'Artist publish guard must prevent duplicate notifications.' );
+
+$existing_post = (object) array(
+	'ID'          => 47,
+	'post_type'   => 'post',
+	'post_author' => 12,
+);
+$test_receipt_statuses = array(
+	4 => 'existing',
+	7 => 'existing',
+	9 => 'existing',
+);
+extrachill_blog_notify_festival_subscribers( 'publish', 'draft', $existing_post );
+extrachill_blog_notify_festival_subscribers( 'publish', 'draft', $existing_post );
+assert_same( 3, count( $test_notifications ), 'Existing receipts must preserve the publish claim.' );
+
+$retry_post = (object) array(
+	'ID'          => 48,
+	'post_type'   => 'post',
+	'post_author' => 12,
+);
+$test_receipt_statuses = array(
+	4 => 'inserted',
+	7 => 'failed',
+	9 => 'inserted',
+);
+extrachill_blog_notify_festival_subscribers( 'publish', 'draft', $retry_post );
+assert_same( '', get_post_meta( 48, EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_NOTIFIED_META, true ), 'A failed recipient must release the publish claim.' );
+
+$test_receipt_statuses = array(
+	4 => 'existing',
+	7 => 'inserted',
+	9 => 'existing',
+);
+extrachill_blog_notify_festival_subscribers( 'publish', 'draft', $retry_post );
+assert_same( 5, count( $test_notifications ), 'A released claim must retry with successful recipients replayed as existing.' );
+assert_same( 'post:48:festival_update', $test_notifications[3]['data']['idempotency_key'], 'Retries must retain the original content-level idempotency key.' );
+assert_same( $test_notifications[3]['data']['idempotency_key'], $test_notifications[4]['data']['idempotency_key'], 'Retry delivery keys must be stable.' );
+
+$invalid_post = (object) array(
+	'ID'          => 49,
+	'post_type'   => 'post',
+	'post_author' => 12,
+);
+$test_invalid_receipt  = true;
+$test_receipt_statuses = array();
+extrachill_blog_notify_festival_subscribers( 'publish', 'draft', $invalid_post );
+assert_same( '', get_post_meta( 49, EXTRACHILL_BLOG_FESTIVAL_SUBSCRIPTION_NOTIFIED_META, true ), 'An invalid receipt must release the publish claim.' );
 
 fwrite( STDOUT, "Entity subscription tests passed.\n" );


### PR DESCRIPTION
## Summary
- migrate artist and festival editorial notifications to canonical receipts
- preserve one delivery per recipient, post, and notification type across overlapping terms
- release publication claims only when a recipient lacks an inserted/existing receipt

## Verification
- `php tests/festival-subscriptions.php`
- targeted WordPress PHPCS
- PHP syntax and `git diff --check`

## Rollout
Merge and deploy this consumer before Extra-Chill/extrachill-users#309 removes the legacy wrapper.

Closes #91