### PR TITLE
refactor: remove artist email-sharing controls

### DIFF
--- a/inc/archive/artist-pillar.php
+++ b/inc/archive/artist-pillar.php
@@ -534,7 +534,7 @@ function extrachill_blog_render_artist_subscription_control() {
 		<section class="entity-pillar-subscription" aria-labelledby="artist-pillar-preferences-title">
 			<h2 id="artist-pillar-preferences-title"><?php esc_html_e( 'Artist preferences', 'extrachill-blog' ); ?></h2>
 			<p>
-				<?php esc_html_e( 'Control artist alerts and email access.', 'extrachill-blog' ); ?>
+				<?php esc_html_e( 'Control Extra Chill notifications for this artist.', 'extrachill-blog' ); ?>
 				<?php if ( $docs_url ) : ?>
 					<a href="<?php echo esc_url( $docs_url ); ?>"><?php esc_html_e( 'How preferences work', 'extrachill-blog' ); ?></a>
 				<?php endif; ?>
@@ -551,7 +551,7 @@ function extrachill_blog_render_artist_subscription_control() {
 		<div class="entity-pillar-preferences__header">
 			<h2 id="artist-pillar-preferences-title"><?php esc_html_e( 'Artist preferences', 'extrachill-blog' ); ?></h2>
 			<p>
-				<?php esc_html_e( 'Control artist alerts and email access.', 'extrachill-blog' ); ?>
+				<?php esc_html_e( 'Control Extra Chill notifications for this artist.', 'extrachill-blog' ); ?>
 				<?php if ( $docs_url ) : ?>
 					<a href="<?php echo esc_url( $docs_url ); ?>"><?php esc_html_e( 'How preferences work', 'extrachill-blog' ); ?></a>
 				<?php endif; ?>
@@ -579,28 +579,6 @@ function extrachill_blog_render_artist_subscription_control() {
 				data-on-status="<?php esc_attr_e( 'On', 'extrachill-blog' ); ?>"
 				data-off-status="<?php esc_attr_e( 'Off', 'extrachill-blog' ); ?>"
 				><?php esc_html_e( 'Turn on', 'extrachill-blog' ); ?></button>
-			</div>
-			<div class="entity-pillar-preferences__control" data-entity-subscription-control>
-				<div class="entity-pillar-preferences__copy">
-					<h3><?php esc_html_e( 'Artist email list', 'extrachill-blog' ); ?></h3>
-					<p class="entity-pillar-subscription-status" aria-live="polite"><?php esc_html_e( 'Checking...', 'extrachill-blog' ); ?></p>
-				</div>
-				<button
-				class="button-1 button-medium entity-pillar-subscription-button"
-				type="button"
-				aria-pressed="false"
-				disabled
-				data-entity-subscription
-				data-entity-type="artist-email-sharing"
-				data-taxonomy="artist"
-				data-slug="<?php echo esc_attr( $term->slug ); ?>"
-				data-endpoint="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>"
-				data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>"
-				data-on-label="<?php esc_attr_e( 'Stop sharing', 'extrachill-blog' ); ?>"
-				data-off-label="<?php esc_attr_e( 'Share email', 'extrachill-blog' ); ?>"
-				data-on-status="<?php esc_attr_e( 'Shared with this artist', 'extrachill-blog' ); ?>"
-				data-off-status="<?php esc_attr_e( 'Not shared with this artist', 'extrachill-blog' ); ?>"
-				><?php esc_html_e( 'Share email', 'extrachill-blog' ); ?></button>
 			</div>
 		</div>
 	</section>

--- a/tests/artist-activity.php
+++ b/tests/artist-activity.php
@@ -89,8 +89,7 @@ assert_same( 'https://community.example.test/t/canonical-topic-42', extrachill_b
 
 $artist_pillar_source         = file_get_contents( dirname( __DIR__ ) . '/inc/archive/artist-pillar.php' );
 $festival_subscriptions_source = file_get_contents( dirname( __DIR__ ) . '/inc/archive/festival-subscriptions.php' );
-assert_same( 3, substr_count( $artist_pillar_source, 'class="button-1 button-medium entity-pillar-subscription-button"' ), 'Artist preference controls should use theme button classes.' );
-assert_true( false !== strpos( $artist_pillar_source, 'data-entity-type="artist-email-sharing"' ), 'Artist preferences must render email sharing separately from notifications.' );
+assert_same( 2, substr_count( $artist_pillar_source, 'class="button-1 button-medium entity-pillar-subscription-button"' ), 'Artist preference controls should use theme button classes.' );
 assert_true( false !== strpos( $artist_pillar_source, 'Artist preferences' ), 'Artist preferences should use one coherent heading.' );
 assert_true( false !== strpos( $artist_pillar_source, "ec_get_site_url( 'docs' )" ), 'Artist preferences should resolve documentation through the network site registry.' );
 assert_true( false === strpos( $artist_pillar_source, 'entity-pillar-preferences__row' ), 'Artist preferences should not render nested notice rows.' );

--- a/tests/entity-subscriptions-js.js
+++ b/tests/entity-subscriptions-js.js
@@ -55,38 +55,45 @@ async function loadScript( buttons, fetch ) {
 		onStatus: 'On',
 		offStatus: 'Off',
 	} );
-	const email = makeButton( {
-		...shared,
-		entityType: 'artist-email-sharing',
-		onLabel: 'Stop sharing',
-		offLabel: 'Share email',
-		onStatus: 'Shared with this artist',
-		offStatus: 'Not shared with this artist',
-	} );
-	let request = 0;
+	let subscribed = false;
+	const requests = [];
 
-	await loadScript( [ notifications, email ], () => {
-		const current = ++request;
+	await loadScript( [ notifications ], ( url, options ) => {
+		requests.push( { url, options } );
+		if ( url.includes( '/entity-subscribe/' ) ) {
+			subscribed = true;
+		} else if ( url.includes( '/entity-unsubscribe/' ) ) {
+			subscribed = false;
+		}
 		return Promise.resolve( {
 			ok: true,
-			json: () => Promise.resolve( { subscribed: 2 === current } ),
+			json: () => Promise.resolve( { subscribed } ),
 		} );
 	} );
 
 	assert.equal( notifications.textContent, 'Turn on' );
 	assert.equal( notifications.status.textContent, 'Off' );
 	assert.equal( notifications.disabled, false );
-	assert.equal( email.textContent, 'Stop sharing' );
-	assert.equal( email.status.textContent, 'Shared with this artist' );
-	assert.equal( email.disabled, false );
+	assert.equal( requests[0].options.method, 'GET' );
+	assert.match( requests[0].url, /entity-subscription-status/ );
+
+	notifications.listeners.click();
+	await flushPromises();
+	assert.equal( notifications.textContent, 'Turn off' );
+	assert.equal( notifications.status.textContent, 'On' );
+	assert.equal( notifications.disabled, false );
+	assert.match( requests[1].url, /entity-subscribe/ );
+	assert.equal( JSON.parse( requests[1].options.body ).input.entity_type, 'artist' );
+
+	notifications.listeners.click();
+	await flushPromises();
+	assert.equal( notifications.textContent, 'Turn on' );
+	assert.equal( notifications.status.textContent, 'Off' );
+	assert.equal( notifications.disabled, false );
+	assert.match( requests[2].url, /entity-unsubscribe/ );
 
 	const unavailable = makeButton( {
-		...shared,
-		entityType: 'artist-email-sharing',
-		onLabel: 'Stop sharing',
-		offLabel: 'Share email',
-		onStatus: 'Shared with this artist',
-		offStatus: 'Not shared with this artist',
+		...notifications.dataset,
 	} );
 	await loadScript( [ unavailable ], () => Promise.reject( new Error( 'offline' ) ) );
 


### PR DESCRIPTION
## Summary
- remove the account-derived artist email-sharing control and email-access copy from editorial artist archives
- retain artist update notifications, login behavior, and the generic entity subscription client
- keep the artist preferences docs link because Extra-Chill/extrachill-docs#66 preserves that page for ordinary artist updates

## Preserved behavior
- artist `artist/artist/<slug>` notification subscribe, unsubscribe, and status behavior remains
- festival subscriptions and publish notifications remain unchanged
- all Extra Chill newsletter forms remain unchanged
- direct Artist Platform Link Page subscriptions remain outside this Blog-owned surface

## Tests
- `composer test:integration` passes
- all functional PHP and JavaScript commands within `composer test` pass
- `vendor/bin/phpcs --standard=WordPress inc/archive/artist-pillar.php` passes
- changed PHP and JavaScript syntax checks pass
- repository grep returns no `artist-email-sharing` or `Share email` matches
- full `composer test` reaches lint and exits on existing unrelated PHPCS findings in `inc/single/login-register-cta.php`, `inc/core/co-authors.php`, `inc/core/admin-customizations.php`, and `inc/core/ads-filter.php`

Closes #98