### PR TITLE
refactor: consume owner activity projections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
             "php tests/homepage-event-markets.php",
             "php tests/festival-subscriptions.php",
             "php tests/artist-activity.php",
+            "php tests/owner-activity-projections.php",
             "php tests/newsletter-context.php",
             "php tests/network-bridge.php",
             "php tests/artist-dispatch.php",

--- a/extrachill-blog.php
+++ b/extrachill-blog.php
@@ -30,6 +30,7 @@ require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/nav.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/co-authors.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/admin-customizations.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/ads-filter.php';
+require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/cross-site-abilities.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/home/homepage-hooks.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/power/power-page.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/submit/artist-dispatch.php';

--- a/inc/archive/artist-pillar.php
+++ b/inc/archive/artist-pillar.php
@@ -100,10 +100,10 @@ add_action( 'extrachill_archive_below_description', 'extrachill_blog_render_arti
 /**
  * Build the artist archive's small, source-owned activity timeline.
  *
- * This is deliberately local to the editorial artist router. Events supply
- * date-aware rows through their existing read ability, while Community's
- * native artist archive supplies topic rows. The Artist Platform contributes
- * only its public profile update timestamp, never profile content.
+ * This is deliberately local to the editorial artist router. Events and
+ * Community supply owner-projected rows through public read abilities. The
+ * Artist Platform contributes only its public profile update timestamp, never
+ * profile content.
  *
  * @param WP_Term $term Artist term.
  * @return array[] Renderable activity items.
@@ -170,30 +170,16 @@ function extrachill_blog_get_artist_coverage_activity( $term ) {
  * @return array[] Activity items.
  */
 function extrachill_blog_get_artist_events_activity( $term ) {
-	if ( ! function_exists( 'ec_cross_site_rest_request' ) ) {
-		return array();
-	}
-
-	$force_loopback = static function () {
-		return true;
-	};
-	add_filter( 'ec_cross_site_use_http_loopback', $force_loopback, 10 );
-	$result = ec_cross_site_rest_request(
+	$result = extrachill_blog_request_cross_site_ability(
 		'events',
-		'GET',
-		'/wp-abilities/v1/abilities/data-machine-events/events-by-term/run',
+		'data-machine-events/events-by-term',
 		array(
-			'query' => array(
-				'input' => array(
-					'taxonomy'  => 'artist',
-					'term_slug' => $term->slug,
-					'scope'     => 'all',
-					'limit'     => 4,
-				),
-			),
+			'taxonomy'  => 'artist',
+			'term_slug' => $term->slug,
+			'scope'     => 'all',
+			'limit'     => 4,
 		)
 	);
-	remove_filter( 'ec_cross_site_use_http_loopback', $force_loopback, 10 );
 
 	if ( is_wp_error( $result ) || ! is_array( $result ) ) {
 		return array();
@@ -223,73 +209,90 @@ function extrachill_blog_get_artist_events_activity( $term ) {
 }
 
 /**
- * Gather the native Community artist archive's recent topics.
- *
- * Community intentionally exposes this surface as an archive, not a REST
- * collection. Match that archive's topic and post-status scope here.
+ * Gather Community-owned recent artist activity.
  *
  * @param WP_Term $term Artist term.
  * @return array[] Activity items.
  */
 function extrachill_blog_get_artist_community_activity( $term ) {
-	if ( ! function_exists( 'ec_get_blog_id' ) || ! ec_get_blog_id( 'community' ) ) {
+	$result = extrachill_blog_request_cross_site_ability(
+		'community',
+		'extrachill/community-recent-public-activity',
+		array(
+			'artist_slug' => (string) $term->slug,
+			'limit'       => 4,
+		)
+	);
+
+	if ( ! extrachill_blog_is_activity_projection( $result ) ) {
 		return array();
 	}
 
 	$items = array();
-	switch_to_blog( (int) ec_get_blog_id( 'community' ) );
-	try {
-		$community_term = get_term_by( 'slug', $term->slug, 'artist' );
-		if ( ! ( $community_term instanceof WP_Term ) ) {
-			return array();
+	foreach ( $result['items'] as $activity ) {
+		if ( ! extrachill_blog_is_community_activity_item( $activity ) ) {
+			continue;
 		}
 
-		$topics = get_posts(
-			array(
-				'post_type'           => 'topic',
-				'post_status'         => array( 'publish', 'closed' ),
-				'posts_per_page'      => 4,
-				'orderby'             => 'date',
-				'order'               => 'DESC',
-				'ignore_sticky_posts' => true,
-				'tax_query'           => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-					array(
-						'taxonomy' => 'artist',
-						'field'    => 'term_id',
-						'terms'    => (int) $community_term->term_id,
-					),
-				),
-			)
+		$items[] = extrachill_blog_build_artist_activity_item(
+			$activity['title'],
+			$activity['canonical_url'],
+			$activity['timestamp'],
+			__( 'Community discussion', 'extrachill-blog' )
 		);
-
-		foreach ( $topics as $topic ) {
-			$items[] = extrachill_blog_build_artist_activity_item(
-				get_the_title( $topic ),
-				extrachill_blog_get_artist_community_topic_permalink( $topic ),
-				get_post_time( 'c', true, $topic ),
-				__( 'Community discussion', 'extrachill-blog' )
-			);
-		}
-	} finally {
-		restore_current_blog();
 	}
 
 	return array_filter( $items );
 }
 
 /**
- * Resolve a Community topic's canonical bbPress permalink.
+ * Validate one version-one Community activity item.
  *
- * @param WP_Post $topic Community topic post.
- * @return string Canonical topic URL.
+ * @param mixed $item Owner-projected item.
+ * @return bool
  */
-function extrachill_blog_get_artist_community_topic_permalink( $topic ) {
-	$topic_id = $topic instanceof WP_Post ? (int) $topic->ID : 0;
-	if ( $topic_id && function_exists( 'bbp_get_topic_permalink' ) ) {
-		return bbp_get_topic_permalink( $topic_id );
+function extrachill_blog_is_community_activity_item( $item ) {
+	if ( ! is_array( $item ) || array( 'canonical_url', 'title', 'timestamp', 'activity_type', 'actor', 'relationships' ) !== array_keys( $item ) ) {
+		return false;
 	}
 
-	return $topic_id ? get_permalink( $topic_id ) : '';
+	return is_string( $item['canonical_url'] )
+		&& false !== filter_var( $item['canonical_url'], FILTER_VALIDATE_URL )
+		&& is_string( $item['title'] )
+		&& '' !== $item['title']
+		&& is_string( $item['timestamp'] )
+		&& false !== strtotime( $item['timestamp'] )
+		&& in_array( $item['activity_type'], array( 'discussion', 'reply' ), true )
+		&& is_array( $item['actor'] )
+		&& array( 'display_name', 'profile_url' ) === array_keys( $item['actor'] )
+		&& is_string( $item['actor']['display_name'] )
+		&& ( null === $item['actor']['profile_url'] || ( is_string( $item['actor']['profile_url'] ) && false !== filter_var( $item['actor']['profile_url'], FILTER_VALIDATE_URL ) ) )
+		&& is_array( $item['relationships'] )
+		&& array( 'forum', 'artists' ) === array_keys( $item['relationships'] )
+		&& extrachill_blog_is_community_term_projection( $item['relationships']['forum'] )
+		&& is_array( $item['relationships']['artists'] )
+		&& 10 >= count( $item['relationships']['artists'] )
+		&& array() === array_filter(
+			$item['relationships']['artists'],
+			static function ( $artist ) {
+				return ! extrachill_blog_is_community_term_projection( $artist );
+			}
+		);
+}
+
+/**
+ * Validate a Community forum or artist relationship.
+ *
+ * @param mixed $term Owner-projected relationship.
+ * @return bool
+ */
+function extrachill_blog_is_community_term_projection( $term ) {
+	return is_array( $term )
+		&& array( 'name', 'slug', 'canonical_url' ) === array_keys( $term )
+		&& is_string( $term['name'] )
+		&& is_string( $term['slug'] )
+		&& is_string( $term['canonical_url'] )
+		&& false !== filter_var( $term['canonical_url'], FILTER_VALIDATE_URL );
 }
 
 /**
@@ -307,19 +310,22 @@ function extrachill_blog_get_artist_platform_activity( $term ) {
 		return true;
 	};
 	add_filter( 'ec_cross_site_use_http_loopback', $force_loopback, 10 );
-	$profiles = ec_cross_site_rest_request(
-		'artist',
-		'GET',
-		'/wp/v2/artist_profile',
-		array(
-			'query' => array(
-				'slug'     => $term->slug,
-				'per_page' => 1,
-				'_fields'  => 'link,modified_gmt,modified',
-			),
-		)
-	);
-	remove_filter( 'ec_cross_site_use_http_loopback', $force_loopback, 10 );
+	try {
+		$profiles = ec_cross_site_rest_request(
+			'artist',
+			'GET',
+			'/wp/v2/artist_profile',
+			array(
+				'query' => array(
+					'slug'     => $term->slug,
+					'per_page' => 1,
+					'_fields'  => 'link,modified_gmt,modified',
+				),
+			)
+		);
+	} finally {
+		remove_filter( 'ec_cross_site_use_http_loopback', $force_loopback, 10 );
+	}
 
 	if ( is_wp_error( $profiles ) || empty( $profiles[0] ) || ! is_array( $profiles[0] ) ) {
 		return array();

--- a/inc/core/cross-site-abilities.php
+++ b/inc/core/cross-site-abilities.php
@@ -49,6 +49,7 @@ function extrachill_blog_request_cross_site_ability( $site_key, $ability_name, $
  * Validate the shared versioned envelope used by activity owners.
  *
  * @param mixed $result Owner response.
+ * @phpstan-assert-if-true array{schema_version: string, items: array} $result
  * @return bool
  */
 function extrachill_blog_is_activity_projection( $result ) {

--- a/inc/core/cross-site-abilities.php
+++ b/inc/core/cross-site-abilities.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Cross-site Ability transport helpers.
+ *
+ * @package ExtraChillBlog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Execute a read-only Ability on its owning site.
+ *
+ * Site-specific plugins require a loopback request so the owner site receives
+ * its normal plugin bootstrap. The temporary transport override must never
+ * escape this request.
+ *
+ * @param string $site_key     Network site key.
+ * @param string $ability_name Registered Ability name.
+ * @param array  $input        Ability input.
+ * @return array|WP_Error Owner response or transport error.
+ */
+function extrachill_blog_request_cross_site_ability( $site_key, $ability_name, $input = array() ) {
+	if ( ! function_exists( 'ec_cross_site_rest_request' ) ) {
+		return new WP_Error( 'extrachill_blog_cross_site_unavailable', __( 'Cross-site activity is unavailable.', 'extrachill-blog' ) );
+	}
+
+	$force_loopback = static function () {
+		return true;
+	};
+
+	add_filter( 'ec_cross_site_use_http_loopback', $force_loopback, 10 );
+	try {
+		return ec_cross_site_rest_request(
+			(string) $site_key,
+			'GET',
+			'/wp-abilities/v1/abilities/' . (string) $ability_name . '/run',
+			array(
+				'query' => array( 'input' => $input ),
+			)
+		);
+	} finally {
+		remove_filter( 'ec_cross_site_use_http_loopback', $force_loopback, 10 );
+	}
+}
+
+/**
+ * Validate the shared versioned envelope used by activity owners.
+ *
+ * @param mixed $result Owner response.
+ * @return bool
+ */
+function extrachill_blog_is_activity_projection( $result ) {
+	return ! is_wp_error( $result )
+		&& is_array( $result )
+		&& array( 'schema_version', 'items' ) === array_keys( $result )
+		&& '1' === $result['schema_version']
+		&& is_array( $result['items'] );
+}

--- a/inc/home/homepage-queries.php
+++ b/inc/home/homepage-queries.php
@@ -157,45 +157,62 @@ function extrachill_blog_prioritize_event_market( $locations, $preferred ) {
 /**
  * Get the latest Festival Wire posts from wire.extrachill.com.
  *
- * Direct cross-blog read via switch_to_blog() — the Wire publishes multiple
- * dispatches per day, so this is the homepage's freshest live signal. Each
- * item carries a humanized age ("3 hours ago") to make recency visible.
+ * Maps the Wire-owned public activity projection into the established
+ * homepage card shape. Each item carries a humanized age ("3 hours ago") to
+ * make recency visible.
  *
  * @param int $limit Number of posts to return.
  * @return array[] Array of items: title, url, time_diff.
  */
 function extrachill_blog_get_wire_latest( $limit = 4 ) {
-	if ( ! function_exists( 'ec_get_blog_id' ) ) {
-		return array();
-	}
+	$limit  = max( 1, min( 20, absint( $limit ) ) );
+	$result = extrachill_blog_request_cross_site_ability(
+		'wire',
+		'extrachill-news-wire/get-recent-activity',
+		array( 'limit' => $limit )
+	);
 
-	$wire_blog_id = ec_get_blog_id( 'wire' );
-	if ( ! $wire_blog_id ) {
+	if ( ! extrachill_blog_is_activity_projection( $result ) ) {
 		return array();
 	}
 
 	$items = array();
+	foreach ( array_slice( $result['items'], 0, $limit ) as $activity ) {
+		if ( ! extrachill_blog_is_wire_activity_item( $activity ) ) {
+			continue;
+		}
 
-	switch_to_blog( $wire_blog_id );
-
-	$wire_posts = get_posts(
-		array(
-			'numberposts' => absint( $limit ),
-			'post_type'   => 'festival_wire',
-		)
-	);
-
-	foreach ( $wire_posts as $wire_post ) {
 		$items[] = array(
-			'title'     => get_the_title( $wire_post ),
-			'url'       => get_permalink( $wire_post ),
-			'time_diff' => human_time_diff( (int) get_post_time( 'U', true, $wire_post ), time() ),
+			'title'     => $activity['title'],
+			'url'       => $activity['canonical_url'],
+			'time_diff' => human_time_diff( strtotime( $activity['timestamp'] ), time() ),
 		);
 	}
 
-	restore_current_blog();
-
 	return $items;
+}
+
+/**
+ * Validate one version-one Wire activity item.
+ *
+ * @param mixed $item Owner-projected item.
+ * @return bool
+ */
+function extrachill_blog_is_wire_activity_item( $item ) {
+	if ( ! is_array( $item ) || array( 'canonical_url', 'title', 'timestamp', 'image', 'summary', 'source', 'type' ) !== array_keys( $item ) ) {
+		return false;
+	}
+
+	return is_string( $item['canonical_url'] )
+		&& false !== filter_var( $item['canonical_url'], FILTER_VALIDATE_URL )
+		&& is_string( $item['title'] )
+		&& '' !== $item['title']
+		&& is_string( $item['timestamp'] )
+		&& false !== strtotime( $item['timestamp'] )
+		&& ( null === $item['image'] || ( is_string( $item['image'] ) && false !== filter_var( $item['image'], FILTER_VALIDATE_URL ) ) )
+		&& ( null === $item['summary'] || is_string( $item['summary'] ) )
+		&& 'extra-chill-news-wire' === $item['source']
+		&& 'festival-wire' === $item['type'];
 }
 
 /**

--- a/tests/artist-activity.php
+++ b/tests/artist-activity.php
@@ -81,14 +81,9 @@ assert_same( 'taxonomy-badge location-badge', $partial_badges[0]['class'], 'A re
 assert_same( array(), extrachill_blog_get_artist_activity_badges( array( 'venue' => 'invalid' ) ), 'Malformed relationship data must be omitted.' );
 assert_same( array(), extrachill_blog_build_artist_activity_item( 'Coverage', 'https://example.test/coverage', '2026-07-14', 'Editorial coverage' )['relationships'], 'Non-event activity rows must not gain relationship badges.' );
 
-function bbp_get_topic_permalink( $topic_id ) { return 'https://community.example.test/t/canonical-topic-' . $topic_id; }
-
-$topic = new WP_Post();
-$topic->ID = 42;
-assert_same( 'https://community.example.test/t/canonical-topic-42', extrachill_blog_get_artist_community_topic_permalink( $topic ), 'Community activity must use the canonical bbPress topic permalink.' );
-
 $artist_pillar_source         = file_get_contents( dirname( __DIR__ ) . '/inc/archive/artist-pillar.php' );
 $festival_subscriptions_source = file_get_contents( dirname( __DIR__ ) . '/inc/archive/festival-subscriptions.php' );
+assert_true( false !== strpos( $artist_pillar_source, 'extrachill/community-recent-public-activity' ), 'Community activity must use the owner projection.' );
 assert_same( 2, substr_count( $artist_pillar_source, 'class="button-1 button-medium entity-pillar-subscription-button"' ), 'Artist preference controls should use theme button classes.' );
 assert_true( false !== strpos( $artist_pillar_source, 'Artist preferences' ), 'Artist preferences should use one coherent heading.' );
 assert_true( false !== strpos( $artist_pillar_source, "ec_get_site_url( 'docs' )" ), 'Artist preferences should resolve documentation through the network site registry.' );

--- a/tests/owner-activity-projections.php
+++ b/tests/owner-activity-projections.php
@@ -1,0 +1,147 @@
+<?php
+/** Focused consumer coverage for Community and Wire activity projections. */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+class WP_Error {}
+class WP_Post {}
+class WP_Term {
+	public $slug = 'test-artist';
+}
+
+$projection_filters  = array();
+$projection_response = array();
+$projection_request  = array();
+$projection_throw    = false;
+
+function add_action() {}
+function __( $text ) { return $text; }
+function get_posts() { return array(); }
+function absint( $value ) { return abs( (int) $value ); }
+function get_option() { return 'F j, Y'; }
+function wp_date( $format, $timestamp ) { return gmdate( $format, $timestamp ); }
+function human_time_diff( $from, $to ) { return (string) ( $to - $from ); }
+function is_wp_error( $value ) { return $value instanceof WP_Error; }
+function add_filter( $hook, $callback ) {
+	$GLOBALS['projection_filters'][ $hook ][] = $callback;
+}
+function remove_filter( $hook, $callback ) {
+	$GLOBALS['projection_filters'][ $hook ] = array_values(
+		array_filter(
+			$GLOBALS['projection_filters'][ $hook ] ?? array(),
+			static function ( $registered ) use ( $callback ) {
+				return $registered !== $callback;
+			}
+		)
+	);
+}
+function ec_cross_site_rest_request( $site_key, $method, $path, $args ) {
+	$GLOBALS['projection_request'] = compact( 'site_key', 'method', 'path', 'args' );
+	if ( $GLOBALS['projection_throw'] ) {
+		throw new RuntimeException( 'Transport failed.' );
+	}
+	return $GLOBALS['projection_response'];
+}
+
+require dirname( __DIR__ ) . '/inc/core/cross-site-abilities.php';
+require dirname( __DIR__ ) . '/inc/archive/artist-pillar.php';
+require dirname( __DIR__ ) . '/inc/home/homepage-queries.php';
+
+function projection_assert( $condition, $message ) {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+$GLOBALS['projection_response'] = array(
+	'schema_version' => '1',
+	'items'          => array(
+		array(
+			'canonical_url' => 'https://community.extrachill.com/topic/test/',
+			'title'         => 'Test discussion',
+			'timestamp'     => '2026-08-06T12:00:00+00:00',
+			'activity_type' => 'discussion',
+			'actor'         => array(
+				'display_name' => 'Test User',
+				'profile_url'  => null,
+			),
+			'relationships' => array(
+				'forum'   => array(
+					'name'          => 'Music',
+					'slug'          => 'music',
+					'canonical_url' => 'https://community.extrachill.com/forums/music/',
+				),
+				'artists' => array(),
+			),
+		),
+	),
+);
+$community = extrachill_blog_get_artist_community_activity( new WP_Term() );
+projection_assert( 1 === count( $community ), 'Community success should map one activity item.' );
+projection_assert( 'Community discussion' === $community[0]['source'], 'Community mapping should preserve the Blog source label.' );
+projection_assert( 'community' === $GLOBALS['projection_request']['site_key'], 'Community requests must target the owner site.' );
+projection_assert( array( 'artist_slug' => 'test-artist', 'limit' => 4 ) === $GLOBALS['projection_request']['args']['query']['input'], 'Artist filtering must be delegated to the owner contract.' );
+projection_assert( empty( $GLOBALS['projection_filters']['ec_cross_site_use_http_loopback'] ), 'Successful dispatch must remove its temporary filter.' );
+
+$GLOBALS['projection_response'] = array(
+	'schema_version' => '1',
+	'items'          => array(
+		array(
+			'canonical_url' => 'https://wire.extrachill.com/festival-wire/test/',
+			'title'         => 'Test dispatch',
+			'timestamp'     => '2026-08-06T12:00:00+00:00',
+			'image'         => null,
+			'summary'       => null,
+			'source'        => 'extra-chill-news-wire',
+			'type'          => 'festival-wire',
+		),
+	),
+);
+$wire = extrachill_blog_get_wire_latest( 4 );
+projection_assert( 1 === count( $wire ), 'Wire success should map one homepage item.' );
+projection_assert( 'Test dispatch' === $wire[0]['title'], 'Wire mapping should preserve the established title field.' );
+projection_assert( 'wire' === $GLOBALS['projection_request']['site_key'], 'Wire requests must target the owner site.' );
+projection_assert( false !== strpos( $GLOBALS['projection_request']['path'], 'extrachill-news-wire/get-recent-activity/run' ), 'Wire requests must execute the merged owner Ability.' );
+
+$GLOBALS['projection_response'] = array( 'schema_version' => '1', 'items' => array() );
+projection_assert( array() === extrachill_blog_get_wire_latest(), 'A versioned empty Wire result should remain empty.' );
+projection_assert( array() === extrachill_blog_get_artist_community_activity( new WP_Term() ), 'A versioned empty Community result should remain empty.' );
+
+$GLOBALS['projection_response'] = new WP_Error();
+projection_assert( array() === extrachill_blog_get_wire_latest(), 'An unavailable Wire owner should fail closed.' );
+projection_assert( array() === extrachill_blog_get_artist_community_activity( new WP_Term() ), 'An unavailable Community owner should fail closed.' );
+
+$GLOBALS['projection_response'] = array( 'schema_version' => '2', 'items' => array() );
+projection_assert( array() === extrachill_blog_get_wire_latest(), 'An unsupported Wire schema should fail closed.' );
+$GLOBALS['projection_response'] = array( 'schema_version' => '1', 'items' => array( array( 'title' => 'Incomplete' ) ) );
+projection_assert( array() === extrachill_blog_get_wire_latest(), 'Malformed Wire items should be omitted.' );
+$GLOBALS['projection_response'] = array( 'schema_version' => '1', 'items' => array( array( 'title' => 'Incomplete' ) ) );
+projection_assert( array() === extrachill_blog_get_artist_community_activity( new WP_Term() ), 'Malformed Community items should be omitted.' );
+
+$GLOBALS['projection_throw'] = true;
+try {
+	extrachill_blog_request_cross_site_ability( 'wire', 'test/throw', array() );
+	projection_assert( false, 'Thrown transport errors should propagate.' );
+} catch ( RuntimeException $error ) {
+	projection_assert( 'Transport failed.' === $error->getMessage(), 'The original transport exception should propagate.' );
+}
+projection_assert( empty( $GLOBALS['projection_filters']['ec_cross_site_use_http_loopback'] ), 'Thrown dispatch must remove its temporary filter.' );
+
+try {
+	extrachill_blog_get_artist_platform_activity( new WP_Term() );
+	projection_assert( false, 'Thrown Artist Platform requests should propagate.' );
+} catch ( RuntimeException $error ) {
+	projection_assert( 'Transport failed.' === $error->getMessage(), 'The Artist Platform request should preserve the transport exception.' );
+}
+projection_assert( empty( $GLOBALS['projection_filters']['ec_cross_site_use_http_loopback'] ), 'Thrown Artist Platform dispatch must remove its temporary filter.' );
+
+$artist_source = file_get_contents( dirname( __DIR__ ) . '/inc/archive/artist-pillar.php' );
+$home_source   = file_get_contents( dirname( __DIR__ ) . '/inc/home/homepage-queries.php' );
+projection_assert( false === strpos( $artist_source, "'post_type'           => 'topic'" ), 'Blog must not query Community topic storage.' );
+projection_assert( false === strpos( $artist_source, 'bbp_get_topic_permalink' ), 'Blog must not call Community permalink helpers.' );
+projection_assert( false === strpos( $artist_source, 'switch_to_blog' ), 'Artist activity must not switch directly into sibling sites.' );
+projection_assert( false === strpos( $home_source, "'post_type'   => 'festival_wire'" ), 'Blog must not query Wire storage.' );
+projection_assert( false === strpos( $home_source, 'switch_to_blog' ), 'Homepage activity must not switch directly into Wire.' );
+
+fwrite( STDOUT, "Owner activity projection tests passed.\n" );


### PR DESCRIPTION
## Summary
- consume Community's public `extrachill/community-recent-public-activity` version-1 contract with owner-side `artist_slug` filtering and map its canonical title, URL, and timestamp into the existing artist timeline
- consume Wire's public `extrachill-news-wire/get-recent-activity` version-1 contract and map its canonical title, URL, and timestamp into the established homepage card shape
- centralize cross-site Ability dispatch through the existing multisite REST transport while guaranteeing temporary loopback filter cleanup with `try/finally`

## Owner contracts
Community remains responsible for public/closed discussion visibility, bbPress storage and status semantics, canonical topic/reply/forum URLs, actor identity, and artist relationships. Blog accepts only the exact version-1 envelope and item shape, delegates bounded artist filtering to the owner, and uses only projected fields.

Wire remains responsible for published and password-free visibility, `festival_wire` storage, canonical URLs, timestamps, optional image/summary values, and stable source/type discriminators. Blog accepts only the exact version-1 envelope and item shape and preserves its current `title`, `url`, and humanized `time_diff` presentation.

## Boundary and failure behavior
- removes direct Community blog switching, topic/status queries, taxonomy lookup, and bbPress permalink helper calls
- removes direct Wire blog switching and `festival_wire` queries
- returns stable empty activity for unavailable owners, transport errors represented by `WP_Error`, unsupported schema versions, empty projections, and malformed items
- bounds both requests to four items at current call sites and retains the Wire contract's maximum of 20

## Cleanup guarantees
- all owner Ability requests force the existing HTTP loopback transport only for the request lifetime and remove that filter in `finally`
- the existing Artist Platform REST request now also removes its temporary loopback filter in `finally`
- focused tests cover successful and thrown transport paths and verify no temporary filter remains installed

## Tests
- `php tests/homepage-event-markets.php`
- `php tests/festival-subscriptions.php`
- `php tests/artist-activity.php`
- `php tests/owner-activity-projections.php`
- `php tests/newsletter-context.php`
- `php tests/network-bridge.php`
- `php tests/artist-dispatch.php`
- `node tests/entity-subscriptions-js.js`
- `node tests/artist-dispatch-js.js`
- `node tests/geographic-bridge-experiment.js`
- changed production scope passes WordPress PHPCS
- Homeboy audit: no introduced findings
- final storage-boundary grep: no matches in the affected Artist/Homepage scope

`composer test` runs all behavioral suites successfully, then reaches the repository's pre-existing PHPCS baseline failures tracked in #83. Homeboy's scoped PHPStan pass reports seven existing findings in legacy portions of the touched files; the new owner-envelope offsets pass after explicit assertion narrowing. Homeboy's PHPUnit stage is not applicable because this repository uses script-based tests and reports that no canonical PHPUnit files exist.

Closes #102