### PR TITLE
feat: expose public festival projections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
             "php tests/festival-subscriptions.php",
             "php tests/artist-activity.php",
             "php tests/owner-activity-projections.php",
+            "php tests/public-entity-projections.php",
             "php tests/newsletter-context.php",
             "php tests/network-bridge.php",
             "php tests/artist-dispatch.php",

--- a/extrachill-blog.php
+++ b/extrachill-blog.php
@@ -31,6 +31,7 @@ require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/co-authors.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/admin-customizations.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/ads-filter.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/cross-site-abilities.php';
+require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/core/public-entity-projections.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/home/homepage-hooks.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/power/power-page.php';
 require_once EXTRACHILL_BLOG_PLUGIN_DIR . 'inc/submit/artist-dispatch.php';

--- a/inc/core/public-entity-projections.php
+++ b/inc/core/public-entity-projections.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Public Blog-owned entity projections.
+ *
+ * @package ExtraChillBlog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const EXTRACHILL_BLOG_PUBLIC_ENTITY_PROJECTION_SCHEMA_VERSION = '1';
+const EXTRACHILL_BLOG_PUBLIC_ENTITY_PROJECTION_MAX_ITEMS      = 100;
+
+add_action( 'wp_abilities_api_categories_init', 'extrachill_blog_register_public_projection_ability_category' );
+add_action( 'wp_abilities_api_init', 'extrachill_blog_register_public_entity_projection_ability' );
+
+/**
+ * Register the Blog ability category.
+ *
+ * @return void
+ */
+function extrachill_blog_register_public_projection_ability_category() {
+	if ( ! function_exists( 'wp_register_ability_category' ) ) {
+		return;
+	}
+
+	if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( 'extrachill-blog' ) ) {
+		return;
+	}
+
+	wp_register_ability_category(
+		'extrachill-blog',
+		array(
+			'label'       => __( 'Extra Chill Blog', 'extrachill-blog' ),
+			'description' => __( 'Public projections owned by the Extra Chill publication.', 'extrachill-blog' ),
+		)
+	);
+}
+
+/**
+ * Register the bounded public entity projection ability.
+ *
+ * @return void
+ */
+function extrachill_blog_register_public_entity_projection_ability() {
+	if ( ! function_exists( 'wp_register_ability' ) ) {
+		return;
+	}
+
+	$item_input_schema = array(
+		'type'                 => 'object',
+		'required'             => array( 'entity_type', 'slug' ),
+		'properties'           => array(
+			'entity_type' => array(
+				'type' => 'string',
+				'enum' => array( 'festival' ),
+			),
+			'slug'        => array(
+				'type'      => 'string',
+				'minLength' => 1,
+				'maxLength' => 200,
+				'pattern'   => '^[a-z0-9]+(?:-[a-z0-9]+)*$',
+			),
+		),
+		'additionalProperties' => false,
+	);
+
+	wp_register_ability(
+		'extrachill/blog-public-entity-projections',
+		array(
+			'label'               => __( 'Get Public Blog Entity Projections', 'extrachill-blog' ),
+			'description'         => __( 'Resolve canonical public Blog presentation for an ordered batch of entity slugs.', 'extrachill-blog' ),
+			'category'            => 'extrachill-blog',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'schema_version', 'items' ),
+				'properties'           => array(
+					'schema_version' => array(
+						'type' => 'string',
+						'enum' => array( EXTRACHILL_BLOG_PUBLIC_ENTITY_PROJECTION_SCHEMA_VERSION ),
+					),
+					'items'          => array(
+						'type'     => 'array',
+						'minItems' => 1,
+						'maxItems' => EXTRACHILL_BLOG_PUBLIC_ENTITY_PROJECTION_MAX_ITEMS,
+						'items'    => $item_input_schema,
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => extrachill_blog_public_entity_projection_output_schema(),
+			'execute_callback'    => 'extrachill_blog_get_public_entity_projections',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Get the exact version-one output schema.
+ *
+ * @return array<string, mixed> JSON Schema definition.
+ */
+function extrachill_blog_public_entity_projection_output_schema() {
+	$common_properties = array(
+		'entity_type' => array(
+			'type' => 'string',
+			'enum' => array( 'festival' ),
+		),
+		'slug'        => array(
+			'type'      => 'string',
+			'minLength' => 1,
+			'maxLength' => 200,
+			'pattern'   => '^[a-z0-9]+(?:-[a-z0-9]+)*$',
+		),
+	);
+	$required          = array( 'entity_type', 'slug', 'status', 'name', 'url' );
+
+	$resolved_properties           = $common_properties;
+	$resolved_properties['status'] = array(
+		'type' => 'string',
+		'enum' => array( 'resolved' ),
+	);
+	$resolved_properties['name']   = array(
+		'type'      => 'string',
+		'minLength' => 1,
+	);
+	$resolved_properties['url']    = array(
+		'type'   => 'string',
+		'format' => 'uri',
+	);
+
+	$missing_properties           = $common_properties;
+	$missing_properties['status'] = array(
+		'type' => 'string',
+		'enum' => array( 'not_found' ),
+	);
+	$missing_properties['name']   = array(
+		'type'      => 'string',
+		'maxLength' => 0,
+	);
+	$missing_properties['url']    = array(
+		'type'      => 'string',
+		'maxLength' => 0,
+	);
+
+	return array(
+		'type'                 => 'object',
+		'required'             => array( 'schema_version', 'items' ),
+		'properties'           => array(
+			'schema_version' => array(
+				'type' => 'string',
+				'enum' => array( EXTRACHILL_BLOG_PUBLIC_ENTITY_PROJECTION_SCHEMA_VERSION ),
+			),
+			'items'          => array(
+				'type'     => 'array',
+				'minItems' => 1,
+				'maxItems' => EXTRACHILL_BLOG_PUBLIC_ENTITY_PROJECTION_MAX_ITEMS,
+				'items'    => array(
+					'oneOf' => array(
+						array(
+							'type'                 => 'object',
+							'required'             => $required,
+							'properties'           => $resolved_properties,
+							'additionalProperties' => false,
+						),
+						array(
+							'type'                 => 'object',
+							'required'             => $required,
+							'properties'           => $missing_properties,
+							'additionalProperties' => false,
+						),
+					),
+				),
+			),
+		),
+		'additionalProperties' => false,
+	);
+}
+
+/**
+ * Resolve public Blog-owned entity presentation in input order.
+ *
+ * @param array<string, mixed> $input Ability input.
+ * @return array<string, mixed>|WP_Error Versioned projection or owner error.
+ */
+function extrachill_blog_get_public_entity_projections( $input ) {
+	$is_main_site = function_exists( 'ec_get_current_site_key' )
+		? 'main' === ec_get_current_site_key()
+		: 1 === (int) get_current_blog_id();
+	if ( ! $is_main_site ) {
+		return new WP_Error( 'extrachill_blog_projection_owner_unavailable', __( 'The Blog projection owner is unavailable.', 'extrachill-blog' ) );
+	}
+
+	if ( ! taxonomy_exists( 'festival' ) ) {
+		return new WP_Error( 'extrachill_blog_projection_taxonomy_unavailable', __( 'Festival projection infrastructure is unavailable.', 'extrachill-blog' ) );
+	}
+
+	$taxonomy = get_taxonomy( 'festival' );
+	if ( ! $taxonomy ) {
+		return new WP_Error( 'extrachill_blog_projection_taxonomy_unavailable', __( 'Festival projection infrastructure is unavailable.', 'extrachill-blog' ) );
+	}
+
+	$items = array();
+	foreach ( array_slice( $input['items'], 0, EXTRACHILL_BLOG_PUBLIC_ENTITY_PROJECTION_MAX_ITEMS ) as $requested ) {
+		$slug = (string) $requested['slug'];
+		$item = array(
+			'entity_type' => 'festival',
+			'slug'        => $slug,
+			'status'      => 'not_found',
+			'name'        => '',
+			'url'         => '',
+		);
+
+		if ( empty( $taxonomy->public ) ) {
+			$items[] = $item;
+			continue;
+		}
+
+		$term = get_term_by( 'slug', $slug, 'festival' );
+		if ( is_wp_error( $term ) ) {
+			return $term;
+		}
+		if ( ! ( $term instanceof WP_Term ) || (int) $term->count < 1 ) {
+			$items[] = $item;
+			continue;
+		}
+
+		$url = get_term_link( $term, 'festival' );
+		if ( is_wp_error( $url ) ) {
+			return $url;
+		}
+		if ( ! is_string( $url ) || '' === $url ) {
+			return new WP_Error( 'extrachill_blog_projection_permalink_unavailable', __( 'The festival canonical permalink is unavailable.', 'extrachill-blog' ) );
+		}
+
+		$item['status'] = 'resolved';
+		$item['name']   = html_entity_decode( (string) $term->name, ENT_QUOTES, 'UTF-8' );
+		$item['url']    = $url;
+		$items[]        = $item;
+	}
+
+	return array(
+		'schema_version' => EXTRACHILL_BLOG_PUBLIC_ENTITY_PROJECTION_SCHEMA_VERSION,
+		'items'          => $items,
+	);
+}

--- a/tests/public-entity-projections.php
+++ b/tests/public-entity-projections.php
@@ -1,0 +1,171 @@
+<?php
+/** Focused coverage for the public Blog entity projection owner contract. */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+class WP_Error {
+	public $code;
+
+	public function __construct( $code = '' ) {
+		$this->code = $code;
+	}
+}
+
+class WP_Term {
+	public $slug;
+	public $name;
+	public $count;
+
+	public function __construct( $slug, $name, $count ) {
+		$this->slug  = $slug;
+		$this->name  = $name;
+		$this->count = $count;
+	}
+}
+
+$projection_ability         = array();
+$projection_category        = array();
+$projection_site_key        = 'main';
+$projection_taxonomy_exists = true;
+$projection_taxonomy_public = true;
+$projection_terms           = array();
+$projection_links           = array();
+
+function add_action() {}
+function __( $text ) { return $text; }
+function __return_true() { return true; }
+function wp_has_ability_category() { return false; }
+function wp_register_ability_category( $name, $args ) {
+	$GLOBALS['projection_category'] = compact( 'name', 'args' );
+}
+function wp_register_ability( $name, $args ) {
+	$GLOBALS['projection_ability'] = compact( 'name', 'args' );
+}
+function ec_get_current_site_key() { return $GLOBALS['projection_site_key']; }
+function get_current_blog_id() { return 1; }
+function taxonomy_exists() { return $GLOBALS['projection_taxonomy_exists']; }
+function get_taxonomy() {
+	return $GLOBALS['projection_taxonomy_exists'] ? (object) array( 'public' => $GLOBALS['projection_taxonomy_public'] ) : false;
+}
+function get_term_by( $field, $slug, $taxonomy ) {
+	return $GLOBALS['projection_terms'][ $slug ] ?? false;
+}
+function get_term_link( $term ) {
+	return $GLOBALS['projection_links'][ $term->slug ] ?? new WP_Error( 'link_failed' );
+}
+function is_wp_error( $value ) { return $value instanceof WP_Error; }
+
+require dirname( __DIR__ ) . '/inc/core/public-entity-projections.php';
+
+function projection_expect( $condition, $message ) {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+extrachill_blog_register_public_projection_ability_category();
+extrachill_blog_register_public_entity_projection_ability();
+
+projection_expect( 'extrachill-blog' === $projection_category['name'], 'The owner category must be registered.' );
+projection_expect( 'extrachill/blog-public-entity-projections' === $projection_ability['name'], 'The public owner ability name must remain stable.' );
+projection_expect( '__return_true' === $projection_ability['args']['permission_callback'], 'The projection must be publicly readable.' );
+projection_expect( true === $projection_ability['args']['meta']['show_in_rest'], 'The projection must use the public core ability runner.' );
+projection_expect( true === $projection_ability['args']['meta']['annotations']['readonly'], 'The projection must remain read-only.' );
+
+$input_schema = $projection_ability['args']['input_schema'];
+$input_item   = $input_schema['properties']['items']['items'];
+projection_expect( array( 'schema_version', 'items' ) === $input_schema['required'], 'Input must require the exact versioned envelope.' );
+projection_expect( false === $input_schema['additionalProperties'], 'Input must reject extra envelope fields.' );
+projection_expect( 1 === $input_schema['properties']['items']['minItems'], 'Input must require at least one item.' );
+projection_expect( 100 === $input_schema['properties']['items']['maxItems'], 'Input must reject more than 100 items.' );
+projection_expect( array( 'entity_type', 'slug' ) === $input_item['required'], 'Each request item must require its exact identity.' );
+projection_expect( false === $input_item['additionalProperties'], 'Request items must reject extra fields.' );
+projection_expect( array( 'festival' ) === $input_item['properties']['entity_type']['enum'], 'Only festival projections are supported.' );
+projection_expect( 1 === $input_item['properties']['slug']['minLength'] && 200 === $input_item['properties']['slug']['maxLength'], 'Slug bounds must be exact.' );
+projection_expect( '^[a-z0-9]+(?:-[a-z0-9]+)*$' === $input_item['properties']['slug']['pattern'], 'Slugs must already be canonical.' );
+
+$output_schema = $projection_ability['args']['output_schema'];
+$variants      = $output_schema['properties']['items']['items']['oneOf'];
+$item_keys     = array( 'entity_type', 'slug', 'status', 'name', 'url' );
+projection_expect( array( 'schema_version', 'items' ) === $output_schema['required'], 'Output must require the exact versioned envelope.' );
+projection_expect( false === $output_schema['additionalProperties'], 'Output must reject extra envelope fields.' );
+projection_expect( 1 === $output_schema['properties']['items']['minItems'], 'Output must preserve at least the required input item.' );
+projection_expect( 100 === $output_schema['properties']['items']['maxItems'], 'Output must never exceed the batch bound.' );
+projection_expect( $item_keys === $variants[0]['required'] && $item_keys === array_keys( $variants[0]['properties'] ), 'Resolved rows must expose exactly the required fields.' );
+projection_expect( $item_keys === $variants[1]['required'] && $item_keys === array_keys( $variants[1]['properties'] ), 'Missing rows must expose exactly the required fields.' );
+projection_expect( false === $variants[0]['additionalProperties'] && false === $variants[1]['additionalProperties'], 'Every output object must reject extra fields.' );
+projection_expect( array( 'resolved' ) === $variants[0]['properties']['status']['enum'], 'Resolved status must be exact.' );
+projection_expect( 1 === $variants[0]['properties']['name']['minLength'] && 'uri' === $variants[0]['properties']['url']['format'], 'Resolved presentation must be non-empty and canonical.' );
+projection_expect( array( 'not_found' ) === $variants[1]['properties']['status']['enum'], 'Missing status must be exact.' );
+projection_expect( 0 === $variants[1]['properties']['name']['maxLength'] && 0 === $variants[1]['properties']['url']['maxLength'], 'Missing presentation must not leak stale data.' );
+
+$projection_terms = array(
+	'public-festival'  => new WP_Term( 'public-festival', 'Public &amp; Loud', 3 ),
+	'private-festival' => new WP_Term( 'private-festival', 'Private Festival', 0 ),
+);
+$projection_links = array(
+	'public-festival' => 'https://extrachill.com/festival/public-festival/',
+);
+$result           = extrachill_blog_get_public_entity_projections(
+	array(
+		'schema_version' => '1',
+		'items'          => array(
+			array( 'entity_type' => 'festival', 'slug' => 'deleted-festival' ),
+			array( 'entity_type' => 'festival', 'slug' => 'public-festival' ),
+			array( 'entity_type' => 'festival', 'slug' => 'private-festival' ),
+			array( 'entity_type' => 'festival', 'slug' => 'public-festival' ),
+		),
+	)
+);
+
+projection_expect( ! is_wp_error( $result ), 'Available owner infrastructure must return a projection.' );
+projection_expect( array( 'schema_version', 'items' ) === array_keys( $result ), 'Runtime output must preserve the exact envelope.' );
+projection_expect( array( 'deleted-festival', 'public-festival', 'private-festival', 'public-festival' ) === array_column( $result['items'], 'slug' ), 'Output must preserve every item and exact input order.' );
+projection_expect( array( 'not_found', 'resolved', 'not_found', 'resolved' ) === array_column( $result['items'], 'status' ), 'Deleted and non-public terms must fail closed.' );
+projection_expect( '' === $result['items'][0]['name'] && '' === $result['items'][0]['url'], 'Deleted terms must not expose stale presentation.' );
+projection_expect( '' === $result['items'][2]['name'] && '' === $result['items'][2]['url'], 'Private terms must not expose presentation.' );
+projection_expect( 'Public & Loud' === $result['items'][1]['name'], 'Resolved names must decode stored entities for display.' );
+projection_expect( 'https://extrachill.com/festival/public-festival/' === $result['items'][1]['url'], 'Canonical URLs must come from the owner permalink API.' );
+projection_expect( $item_keys === array_keys( $result['items'][1] ), 'Runtime rows must match the exact required schema.' );
+
+$projection_taxonomy_public = false;
+$hidden                     = extrachill_blog_get_public_entity_projections(
+	array(
+		'schema_version' => '1',
+		'items'          => array( array( 'entity_type' => 'festival', 'slug' => 'public-festival' ) ),
+	)
+);
+projection_expect( 'not_found' === $hidden['items'][0]['status'], 'A non-public owner taxonomy must fail closed.' );
+projection_expect( '' === $hidden['items'][0]['name'] && '' === $hidden['items'][0]['url'], 'A non-public taxonomy must not leak presentation.' );
+$projection_taxonomy_public = true;
+
+$projection_links['public-festival'] = new WP_Error( 'link_failed' );
+$link_error                          = extrachill_blog_get_public_entity_projections(
+	array(
+		'schema_version' => '1',
+		'items'          => array( array( 'entity_type' => 'festival', 'slug' => 'public-festival' ) ),
+	)
+);
+projection_expect( is_wp_error( $link_error ) && 'link_failed' === $link_error->code, 'Canonical permalink failures must remain owner errors.' );
+$projection_links['public-festival'] = 'https://extrachill.com/festival/public-festival/';
+
+$projection_taxonomy_exists = false;
+$unavailable                = extrachill_blog_get_public_entity_projections(
+	array(
+		'schema_version' => '1',
+		'items'          => array( array( 'entity_type' => 'festival', 'slug' => 'public-festival' ) ),
+	)
+);
+projection_expect( is_wp_error( $unavailable ) && 'extrachill_blog_projection_taxonomy_unavailable' === $unavailable->code, 'Missing owner taxonomy infrastructure must remain an error.' );
+$projection_taxonomy_exists = true;
+
+$projection_site_key = 'community';
+$wrong_owner         = extrachill_blog_get_public_entity_projections(
+	array(
+		'schema_version' => '1',
+		'items'          => array( array( 'entity_type' => 'festival', 'slug' => 'public-festival' ) ),
+	)
+);
+projection_expect( is_wp_error( $wrong_owner ) && 'extrachill_blog_projection_owner_unavailable' === $wrong_owner->code, 'Wrong-site execution must remain an owner availability error.' );
+
+print "Public Blog entity projection tests passed.\n";


### PR DESCRIPTION
## Summary
- expose the public read-only `extrachill/blog-public-entity-projections` owner ability for ordered festival slug batches
- keep festival lookup, visibility, display name, and canonical permalink generation inside Blog/Main
- return exact `resolved` or `not_found` rows without introducing a cross-domain registry or duplicating taxonomy state

## Contract
- input is an exact `{ schema_version: \"1\", items: [...] }` object with 1-100 ordered items
- each input item is exactly `{ entity_type: \"festival\", slug }`; slugs must be canonical lowercase hyphenated values 1-200 characters long
- output preserves one row per input in order with exactly `entity_type`, `slug`, `status`, `name`, and `url`
- resolved rows require a non-empty display name and canonical URI; not-found rows require empty `name` and `url`
- `additionalProperties: false` applies to every object schema

## Visibility And Canonical URL
- a festival resolves only when the Main-site `festival` taxonomy is public and the term has published content
- stale, deleted, zero-public-content, or otherwise non-public festivals return `not_found` with no stale presentation data
- canonical URLs come from WordPress core `get_term_link()` on the Blog owner site
- wrong-site bootstrap, unavailable taxonomy infrastructure, lookup failures, and permalink failures remain `WP_Error`

## Tests
- `php tests/public-entity-projections.php`
- `composer test:integration`
- changed production files pass WordPress PHPCS and PHP lint
- WordPress core schema validation passes valid resolved/not-found contracts and rejects malformed versions, slugs, extra fields, empty batches, oversized batches, and stale not-found data
- the full `composer test` functional suite passes before its configured repository-wide PHPCS step reaches pre-existing violations in untouched files (`inc/single/login-register-cta.php`, `inc/core/co-authors.php`, `inc/core/admin-customizations.php`, and `inc/core/ads-filter.php`)
- PHPStan is not installed/configured in this repository
- the tracked `build.sh` symlink targets a missing shared `/var/lib/datamachine/.github/build.sh`, so no repository build could run

Closes #103.

Unblocks Extra-Chill/extrachill-community#266.