### PR TITLE
fix: restore release lint for entity projections

### DIFF
--- a/inc/archive/artist-pillar.php
+++ b/inc/archive/artist-pillar.php
@@ -105,7 +105,7 @@ add_action( 'extrachill_archive_below_description', 'extrachill_blog_render_arti
  * Artist Platform contributes only its public profile update timestamp, never
  * profile content.
  *
- * @param WP_Term $term Artist term.
+ * @param mixed $term Artist term.
  * @return array[] Renderable activity items.
  */
 function extrachill_blog_get_artist_activity( $term ) {
@@ -155,7 +155,7 @@ function extrachill_blog_get_artist_coverage_activity( $term ) {
 		$items[] = extrachill_blog_build_artist_activity_item(
 			get_the_title( $post ),
 			get_permalink( $post ),
-			get_post_time( 'c', true, $post ),
+			(string) get_post_time( 'c', true, $post ),
 			__( 'Editorial coverage', 'extrachill-blog' )
 		);
 	}
@@ -181,7 +181,7 @@ function extrachill_blog_get_artist_events_activity( $term ) {
 		)
 	);
 
-	if ( is_wp_error( $result ) || ! is_array( $result ) ) {
+	if ( is_wp_error( $result ) ) {
 		return array();
 	}
 
@@ -354,7 +354,7 @@ function extrachill_blog_get_artist_platform_activity( $term ) {
  * @param string $date_display Source-formatted date, when available.
  * @param string $context      Source-owned venue and time context, when available.
  * @param string $timing       Source-owned upcoming or past timing, when available.
- * @param array  $relationships Events-owned venue, location, and festival relationships.
+ * @param mixed  $relationships Events-owned venue, location, and festival relationships.
  * @return array|null Activity item.
  */
 function extrachill_blog_build_artist_activity_item( $title, $url, $date, $source, $date_display = '', $context = '', $timing = '', $relationships = array() ) {
@@ -379,7 +379,7 @@ function extrachill_blog_build_artist_activity_item( $title, $url, $date, $sourc
 /**
  * Return renderable taxonomy badges from Events-owned relationship objects.
  *
- * @param array $relationships Event relationship data.
+ * @param mixed $relationships Event relationship data.
  * @return array[] Badge data.
  */
 function extrachill_blog_get_artist_activity_badges( $relationships ) {

--- a/inc/core/public-entity-projections.php
+++ b/inc/core/public-entity-projections.php
@@ -226,9 +226,6 @@ function extrachill_blog_get_public_entity_projections( $input ) {
 		}
 
 		$term = get_term_by( 'slug', $slug, 'festival' );
-		if ( is_wp_error( $term ) ) {
-			return $term;
-		}
 		if ( ! ( $term instanceof WP_Term ) || (int) $term->count < 1 ) {
 			$items[] = $item;
 			continue;
@@ -238,7 +235,7 @@ function extrachill_blog_get_public_entity_projections( $input ) {
 		if ( is_wp_error( $url ) ) {
 			return $url;
 		}
-		if ( ! is_string( $url ) || '' === $url ) {
+		if ( '' === $url ) {
 			return new WP_Error( 'extrachill_blog_projection_permalink_unavailable', __( 'The festival canonical permalink is unavailable.', 'extrachill-blog' ) );
 		}
 

--- a/inc/home/homepage-queries.php
+++ b/inc/home/homepage-queries.php
@@ -306,7 +306,7 @@ function extrachill_blog_fetch_recently_shipped() {
 
 		$release = $release_data;
 
-		if ( empty( $release['tag_name'] ) || empty( $release['published_at'] ) || empty( $release['html_url'] ) ) {
+		if ( empty( $release['published_at'] ) || empty( $release['html_url'] ) ) {
 			continue;
 		}
 

--- a/tests/homepage-network-hub.php
+++ b/tests/homepage-network-hub.php
@@ -39,7 +39,7 @@ function home_url( $path = '' ) {
 function number_format_i18n( $number ) {
 	return number_format( $number );
 }
-function ec_get_network_stats() {
+function ec_get_network_stats( $keys = array() ) {
 	return array();
 }
 function ec_get_site_url( $site_key ) {


### PR DESCRIPTION
## Summary
- align artist activity input annotations and WordPress return handling with the runtime contracts PHPStan analyzes
- remove impossible core return branches and duplicate GitHub release payload validation without changing projection or homepage output
- update the network stats test stub to match the production helper's optional key filter
- keep the retired artist and festival follow surfaces retired

## Root causes
- defensive runtime checks contradicted declared `WP_Term`, array, and WordPress core return contracts, producing always-true or impossible-branch findings
- `get_post_time()` was passed through without normalizing its documented `int|string|false` return to the activity builder's string contract
- the Recently Shipped payload validated `tag_name` twice, and a zero-argument test stub shadowed the real optional-argument `ec_get_network_stats()` signature

## Verification
- `homeboy review lint extrachill-blog --path /var/lib/datamachine/workspace/extrachill-blog@fix-83-release-lint --placement local --changed-since v0.15.3` (PHPCS and PHPStan level 7 pass with no findings)
- focused artist activity and owner activity projection tests
- focused public entity projection contract tests
- focused homepage event-market and network-hub tests
- complete declared functional suite: all PHP and JavaScript test scripts pass
- `git diff --check`

## Residual risk
- Homeboy's generic PHPUnit adapter does not discover this repository's standalone script tests; the repository-declared scripts were therefore executed directly and all passed.
- No live cross-site requests were made. The production changes are limited to static type normalization and redundant checks around existing contracts.

Fixes #83