### PR TITLE
fix: clear remaining release lint

### DIFF
--- a/inc/core/cross-site-abilities.php
+++ b/inc/core/cross-site-abilities.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param string $site_key     Network site key.
  * @param string $ability_name Registered Ability name.
  * @param array  $input        Ability input.
- * @return array|WP_Error Owner response or transport error.
+ * @return array|string|WP_Error Owner response or transport error.
  */
 function extrachill_blog_request_cross_site_ability( $site_key, $ability_name, $input = array() ) {
 	if ( ! function_exists( 'ec_cross_site_rest_request' ) ) {

--- a/inc/home/homepage-queries.php
+++ b/inc/home/homepage-queries.php
@@ -355,14 +355,10 @@ function extrachill_blog_get_hero_stats() {
 	$keys  = array( 'events_count', 'events_cities', 'total_members', 'artist_profiles' );
 	$stats = ec_get_network_stats( $keys );
 
-	if ( ! is_array( $stats ) ) {
-		return array();
-	}
-
 	$values = array();
 
 	foreach ( $keys as $key ) {
-		if ( empty( $stats[ $key ] ) || ! is_array( $stats[ $key ] ) ) {
+		if ( empty( $stats[ $key ] ) ) {
 			continue;
 		}
 


### PR DESCRIPTION
## Summary
- remove redundant guards around the typed network stats contract
- align the Blog cross-site wrapper return annotation with Network's raw-response fallback
- clear the complete `v0.15.3..HEAD` release lint range after #106

## Verification
- full release-range PHPCS, ESLint, and PHPStan: zero findings
- homepage network hub tests pass
- public entity projection tests pass
- architecture audit: zero introduced findings
- PHP syntax and `git diff --check` pass

Fixes #83